### PR TITLE
remove deal.II 9.5 from github tester

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -107,11 +107,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: "geodynamics/aspect-tester:focal-dealii-9.5-v3"
-            run-tests: "ON"
-            compare-tests: "OFF"
-            result-file: "changes-test-results-9.5.diff"
-            container-options: '--name container'
           - image: "geodynamics/aspect-tester:jammy-dealii-9.6-v1"
             run-tests: "ON"
             compare-tests: "ON"


### PR DESCRIPTION
This is necessary because our external mesh deformation base class requires 9.6. (#9)