### PR TITLE
mesh deformation: support parallel evaluation

### DIFF
--- a/include/aspect/mesh_deformation/external_tool_interface.h
+++ b/include/aspect/mesh_deformation/external_tool_interface.h
@@ -204,8 +204,21 @@ namespace aspect
         struct DofToEvalPointData
         {
           types::global_dof_index dof_index;
-          unsigned int evaluation_point_index;
-          unsigned int component;
+          unsigned int            evaluation_point_rank;
+          unsigned int            evaluation_point_index;
+          unsigned int            component;
+          double                  squared_distance;
+
+          template <class Archive>
+          void
+          serialize(Archive &ar, const unsigned int /*version*/)
+          {
+            ar &dof_index;
+            ar &evaluation_point_rank;
+            ar &evaluation_point_index;
+            ar &component;
+            ar &squared_distance;
+          }
         };
 
         /**

--- a/source/mesh_deformation/external_tool_interface.cc
+++ b/source/mesh_deformation/external_tool_interface.cc
@@ -116,7 +116,10 @@ namespace aspect
         const DoFHandler<dim> &mesh_dof_handler = this->get_mesh_deformation_handler().get_mesh_deformation_dof_handler();
 
         std::vector<double> squared_distances(mesh_dof_handler.locally_owned_dofs().size(), std::numeric_limits<double>::max());
-        DofToEvalPointData invalid {numbers::invalid_dof_index, numbers::invalid_unsigned_int, numbers::invalid_unsigned_int, numbers::invalid_unsigned_int, -1.0};
+        const DofToEvalPointData invalid
+        {
+          numbers::invalid_dof_index, numbers::invalid_unsigned_int, numbers::invalid_unsigned_int, numbers::invalid_unsigned_int, -1.0
+        };
         std::vector<DofToEvalPointData> closest_evaluation_point_and_component(mesh_dof_handler.locally_owned_dofs().size(), invalid);
 
         // TODO: do we need to support the case of more than one different mesh deformation plugin to be active?
@@ -133,6 +136,14 @@ namespace aspect
         // For each support point of the velocity DoFHandler, we will try to find the closest evaluation point. We
         // do this by keeping track of the squared distance of the closest evaluation point checked so far.
 
+        // For each evaluation point, we store the index and MPI rank to be able to identify them later:
+        const unsigned int n_components = 2;
+        std::vector<unsigned int> indices (evaluation_points.size() * n_components);
+        for (unsigned int i=0; i<evaluation_points.size(); ++i)
+          {
+            indices[n_components*i] = i;
+            indices[n_components*i+1] = my_rank;
+          }
 
         // Note: We assume that process_and_evaluate() does not call our lambda concurrently, otherwise we would have write
         // conflicts when updating closest_evaluation_point_and_component and squared_distances.
@@ -150,18 +161,20 @@ namespace aspect
 
               const ArrayView<const Point<dim>> unit_points = cell_data.get_unit_points(cell_index);
 
-              // TODO: cell_data.get_data_view() does not work with 2 components:
+
+              // Grab the values for this cell containing index and rank for each evaluation point.
+              // Note: cell_data.get_data_view() does not work correctly with 2 components.
               const ArrayView<const unsigned int> local_values(
                 values.data() +
-                2*cell_data.reference_point_ptrs[cell_index],
-                2*(cell_data.reference_point_ptrs[cell_index + 1] -
-                   cell_data.reference_point_ptrs[cell_index]));
+                n_components*cell_data.reference_point_ptrs[cell_index],
+                n_components*(cell_data.reference_point_ptrs[cell_index + 1] -
+                              cell_data.reference_point_ptrs[cell_index]));
 
               const std::vector< Point< dim >> &support_points = mesh_dof_handler.get_fe().get_unit_support_points();
               for (unsigned int i=0; i<unit_points.size(); ++i)
                 {
-                  const unsigned int point_index = local_values[2*i];
-                  const unsigned int rank = local_values[2*i+1];
+                  const unsigned int point_index = local_values[n_components*i];
+                  const unsigned int rank = local_values[n_components*i+1];
 
                   for (unsigned int j=0; j<support_points.size(); ++j)
                     {
@@ -178,21 +191,13 @@ namespace aspect
             }
         };
 
-        // store index and rank for each evaluation point:
-        std::vector<unsigned int> indices (evaluation_points.size() * 2);
-        if (evaluation_points.size() > 0)
-          {
-            for (unsigned int i=0; i<evaluation_points.size(); ++i)
-              {
-                indices[2*i] = i;
-                indices[2*i+1] = my_rank;
-              }
-          }
-        this->remote_point_evaluator->template process_and_evaluate<unsigned int, 2>(indices, eval_func, /*sort_data*/ true);
+
+        this->remote_point_evaluator->template process_and_evaluate<unsigned int, n_components>(indices, eval_func, /*sort_data*/ true);
 
         // remove DoFs not found (for example not surface DoFs):
-        auto new_end_it = std::remove_if(closest_evaluation_point_and_component.begin(), closest_evaluation_point_and_component.end(),
-                                         [](const DofToEvalPointData &data)
+        const auto new_end_it = std::remove_if(closest_evaluation_point_and_component.begin(),
+                                               closest_evaluation_point_and_component.end(),
+                                               [](const DofToEvalPointData &data)
         {
           return data.dof_index == numbers::invalid_dof_index;
         });
@@ -204,30 +209,28 @@ namespace aspect
 
         if (my_rank == 0)
           {
+            // Combine data coming from all ranks and determine closest evaluation point for each DoF:
             std::map<types::global_dof_index, DofToEvalPointData> map_from_dof;
             for (const auto &data : all_closest_evaluation_point_and_component)
               for (const auto &p : data)
                 {
-                  if (map_from_dof.find(p.dof_index) == map_from_dof.end())
+                  const bool not_found = (map_from_dof.find(p.dof_index) == map_from_dof.end());
+                  if (not_found || p.squared_distance < map_from_dof[p.dof_index].squared_distance)
                     map_from_dof[p.dof_index] = p;
-                  else
-                    {
-                      if (p.squared_distance < map_from_dof[p.dof_index].squared_distance)
-                        map_from_dof[p.dof_index] = p;
-                    }
                 }
 
-            // compile data for each rank and send it:
+            // Compile data for each rank and send it:
             std::vector<std::vector<DofToEvalPointData>> map_from_rank(n_mpi_processes);
-            for (const auto &data : map_from_dof)
-              map_from_rank[data.second.evaluation_point_rank].push_back(data.second);
+            for (const auto &[dof_index, eval_point_data] : map_from_dof)
+              map_from_rank[eval_point_data.evaluation_point_rank].push_back(eval_point_data);
 
             map_dof_to_eval_point = Utilities::MPI::scatter (this->get_mpi_communicator(), map_from_rank, 0);
           }
         else
           {
-            std::vector<std::vector<DofToEvalPointData>> map_from_rank;
-            map_dof_to_eval_point = Utilities::MPI::scatter (this->get_mpi_communicator(), map_from_rank, 0);
+            // Receive my data from rank 0:
+            std::vector<std::vector<DofToEvalPointData>> dummy;
+            map_dof_to_eval_point = Utilities::MPI::scatter (this->get_mpi_communicator(), dummy, 0);
           }
       }
 

--- a/source/mesh_deformation/external_tool_interface.cc
+++ b/source/mesh_deformation/external_tool_interface.cc
@@ -107,16 +107,17 @@ namespace aspect
       // Create a mapping from evaluation points to support points. Note that one evaluation point can map to
       // multiple support points.
       {
-        // For now, we only support a single MPI rank for ASPECT and the external mesh deformation class. Because deciding
-        // which evaluation point is closest to a support point requires somewhat complex MPI communication.
-        Assert(Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) == 1,
-               ExcNotImplemented("This function is not implemented for parallel computations."));
+        // Deciding which evaluation point is closest to a support point requires somewhat complex MPI communication.
+        // For now, we just gather all data on rank 0, do the computation, and then scatter the results back.
+
+        const unsigned int n_mpi_processes = Utilities::MPI::n_mpi_processes(this->get_mpi_communicator());
+        const unsigned int my_rank = Utilities::MPI::this_mpi_process(this->get_mpi_communicator());
 
         const DoFHandler<dim> &mesh_dof_handler = this->get_mesh_deformation_handler().get_mesh_deformation_dof_handler();
 
         std::vector<double> squared_distances(mesh_dof_handler.locally_owned_dofs().size(), std::numeric_limits<double>::max());
-        std::vector<DofToEvalPointData> closest_evaluation_point_and_component(mesh_dof_handler.locally_owned_dofs().size(),
-                                                                               DofToEvalPointData {numbers::invalid_dof_index, numbers::invalid_unsigned_int, numbers::invalid_unsigned_int});
+        DofToEvalPointData invalid {numbers::invalid_dof_index, numbers::invalid_unsigned_int, numbers::invalid_unsigned_int, numbers::invalid_unsigned_int, -1.0};
+        std::vector<DofToEvalPointData> closest_evaluation_point_and_component(mesh_dof_handler.locally_owned_dofs().size(), invalid);
 
         // TODO: do we need to support the case of more than one different mesh deformation plugin to be active?
         const auto boundary_ids = this->get_mesh_deformation_boundary_indicators();
@@ -148,11 +149,20 @@ namespace aspect
               cell_dofs->get_dof_indices(cell_dof_indices);
 
               const ArrayView<const Point<dim>> unit_points = cell_data.get_unit_points(cell_index);
-              const auto local_values = cell_data.get_data_view(cell_index, values);
+
+              // TODO: cell_data.get_data_view() does not work with 2 components:
+              const ArrayView<const unsigned int> local_values(
+                values.data() +
+                2*cell_data.reference_point_ptrs[cell_index],
+                2*(cell_data.reference_point_ptrs[cell_index + 1] -
+                   cell_data.reference_point_ptrs[cell_index]));
 
               const std::vector< Point< dim >> &support_points = mesh_dof_handler.get_fe().get_unit_support_points();
               for (unsigned int i=0; i<unit_points.size(); ++i)
                 {
+                  const unsigned int point_index = local_values[2*i];
+                  const unsigned int rank = local_values[2*i+1];
+
                   for (unsigned int j=0; j<support_points.size(); ++j)
                     {
                       const double distance_sq = unit_points[i].distance_square(support_points[j]);
@@ -161,22 +171,63 @@ namespace aspect
                           squared_distances[cell_dof_indices[j]] = distance_sq;
                           const unsigned int component = mesh_dof_handler.get_fe().system_to_component_index(j).first;
                           closest_evaluation_point_and_component[cell_dof_indices[j]] =
-                            DofToEvalPointData {cell_dof_indices[j], local_values[i], component};
+                            DofToEvalPointData {cell_dof_indices[j], rank, point_index, component, distance_sq};
                         }
                     }
                 }
             }
         };
 
-        std::vector<unsigned int> indices (evaluation_points.size());
-        std::iota(indices.begin(), indices.end(), 0);
-        this->remote_point_evaluator->template process_and_evaluate<unsigned int, 1>(indices, eval_func, /*sort_data*/ true);
-
-        map_dof_to_eval_point.clear();
-        for (unsigned int i=0; i<closest_evaluation_point_and_component.size(); ++i)
+        // store index and rank for each evaluation point:
+        std::vector<unsigned int> indices (evaluation_points.size() * 2);
+        if (evaluation_points.size() > 0)
           {
-            if (closest_evaluation_point_and_component[i].dof_index != numbers::invalid_dof_index)
-              map_dof_to_eval_point.push_back(closest_evaluation_point_and_component[i]);
+            for (unsigned int i=0; i<evaluation_points.size(); ++i)
+              {
+                indices[2*i] = i;
+                indices[2*i+1] = my_rank;
+              }
+          }
+        this->remote_point_evaluator->template process_and_evaluate<unsigned int, 2>(indices, eval_func, /*sort_data*/ true);
+
+        // remove DoFs not found (for example not surface DoFs):
+        auto new_end_it = std::remove_if(closest_evaluation_point_and_component.begin(), closest_evaluation_point_and_component.end(),
+                                         [](const DofToEvalPointData &data)
+        {
+          return data.dof_index == numbers::invalid_dof_index;
+        });
+        closest_evaluation_point_and_component.erase(new_end_it, closest_evaluation_point_and_component.end());
+
+        // send to rank 0 and find the closest evaluation point across all ranks:
+        std::vector<std::vector<DofToEvalPointData>> all_closest_evaluation_point_and_component
+          = Utilities::MPI::gather(this->get_mpi_communicator(), closest_evaluation_point_and_component, /* root = */ 0);
+
+        if (my_rank == 0)
+          {
+            std::map<types::global_dof_index, DofToEvalPointData> map_from_dof;
+            for (const auto &data : all_closest_evaluation_point_and_component)
+              for (const auto &p : data)
+                {
+                  if (map_from_dof.find(p.dof_index) == map_from_dof.end())
+                    map_from_dof[p.dof_index] = p;
+                  else
+                    {
+                      if (p.squared_distance < map_from_dof[p.dof_index].squared_distance)
+                        map_from_dof[p.dof_index] = p;
+                    }
+                }
+
+            // compile data for each rank and send it:
+            std::vector<std::vector<DofToEvalPointData>> map_from_rank(n_mpi_processes);
+            for (const auto &data : map_from_dof)
+              map_from_rank[data.second.evaluation_point_rank].push_back(data.second);
+
+            map_dof_to_eval_point = Utilities::MPI::scatter (this->get_mpi_communicator(), map_from_rank, 0);
+          }
+        else
+          {
+            std::vector<std::vector<DofToEvalPointData>> map_from_rank;
+            map_dof_to_eval_point = Utilities::MPI::scatter (this->get_mpi_communicator(), map_from_rank, 0);
           }
       }
 

--- a/tests/mesh_deformation_external_01.cc
+++ b/tests/mesh_deformation_external_01.cc
@@ -70,8 +70,6 @@ namespace aspect
                           points.emplace_back(0.1+x*1.0/5, 0.1+y*1.0/5, 1.0);
                     }
                 }
-              else
-                Assert(false, ExcNotImplemented());
 
               this->set_evaluation_points (points);
 

--- a/tests/mesh_deformation_external_01_mpi.cc
+++ b/tests/mesh_deformation_external_01_mpi.cc
@@ -1,0 +1,21 @@
+/*
+  Copyright (C) 2025 - 2025 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include "mesh_deformation_external_01.cc"

--- a/tests/mesh_deformation_external_01_mpi.prm
+++ b/tests/mesh_deformation_external_01_mpi.prm
@@ -1,0 +1,7 @@
+# Test the ExternalToolInterface class for mesh deformation
+# derived class written as a plugin
+# Like mesh_deformation_external_01.prm but with MPI.
+#
+# MPI: 2
+
+include $ASPECT_SOURCE_DIR/tests/mesh_deformation_external_01.prm

--- a/tests/mesh_deformation_external_01_mpi/screen-output
+++ b/tests/mesh_deformation_external_01_mpi/screen-output
@@ -1,0 +1,268 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libmesh_deformation_external_01_mpi.debug.so>
+
+initialize()
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 948 (578+81+289)
+
+Number of mesh deformation degrees of freedom: 162
+   Solving mesh displacement system... 6 iterations.
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+update()
+	setting points
+map_dof_to_eval_point (dof, evaluation_point_index, component): 
+	110 0 0
+	111 0 1
+	112 1 0
+	113 1 1
+	114 2 0
+	115 2 1
+	116 0 0
+	117 0 1
+	118 1 0
+	119 1 1
+	120 2 0
+	121 2 1
+	122 4 0
+	123 4 1
+	124 5 0
+	125 5 1
+	126 4 0
+	127 4 1
+	128 5 0
+	129 5 1
+	146 6 0
+	147 6 1
+	148 8 0
+	149 8 1
+	150 6 0
+	151 6 1
+	152 8 0
+	153 8 1
+	154 9 0
+	155 9 1
+	156 10 0
+	157 10 1
+	158 9 0
+	159 9 1
+	160 10 0
+	161 10 1
+compute_updated_velocities_at_points()
+Solution at evaluation points:
+rank 0:
+0.05 1 0 0 0 100.05
+0.140909 1 0 0 0 100.141
+0.231818 1 0 0 0 100.232
+0.322727 1 0 0 0 100.323
+0.413636 1 0 0 0 100.414
+0.504545 1 0 0 0 100.505
+0.595455 1 0 0 0 100.595
+0.686364 1 0 0 0 100.686
+0.777273 1 0 0 0 100.777
+0.868182 1 0 0 0 100.868
+0.959091 1 0 0 0 100.959
+rank 1:
+   Solving mesh displacement system... 4 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-mesh_deformation_external_01_mpi/solution/solution-00000
+     Topography min/max:       0 m, 0.1 m
+
+*** Timestep 1:  t=0.0005 seconds, dt=0.0005 seconds
+update()
+compute_updated_velocities_at_points()
+Solution at evaluation points:
+rank 0:
+0.05 1 0 0 0 100.05
+0.140909 1 0 0 0 100.141
+0.231818 1 0 0 0 100.232
+0.322727 1 0 0 0 100.323
+0.413636 1 0 0 0 100.414
+0.504545 1 0 0 0 100.505
+0.595455 1 0 0 0 100.595
+0.686364 1 0 0 0 100.686
+0.777273 1 0 0 0 100.777
+0.868182 1 0 0 0 100.868
+0.959091 1 0 0 0 100.959
+rank 1:
+   Solving mesh displacement system... 4 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-mesh_deformation_external_01_mpi/solution/solution-00001
+     Topography min/max:       -0.0025 m, 0.1 m
+
+*** Timestep 2:  t=0.001 seconds, dt=0.0005 seconds
+update()
+compute_updated_velocities_at_points()
+Solution at evaluation points:
+rank 0:
+0.05 1 0 0 0 100.05
+0.140909 1 0 0 0 100.141
+0.231818 1 0 0 0 100.232
+0.322727 1 0 0 0 100.323
+0.413636 1 0 0 0 100.414
+0.504545 1 0 0 0 100.505
+0.595455 1 0 0 0 100.595
+0.686364 1 0 0 0 100.686
+0.777273 1 0 0 0 100.777
+0.868182 1 0 0 0 100.868
+0.959091 1 0 0 0 100.959
+rank 1:
+   Solving mesh displacement system... 4 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-mesh_deformation_external_01_mpi/solution/solution-00002
+     Topography min/max:       -0.005 m, 0.1 m
+
+*** Timestep 3:  t=0.0015 seconds, dt=0.0005 seconds
+update()
+compute_updated_velocities_at_points()
+Solution at evaluation points:
+rank 0:
+0.05 1 0 0 0 100.05
+0.140909 1 0 0 0 100.141
+0.231818 1 0 0 0 100.232
+0.322727 1 0 0 0 100.323
+0.413636 1 0 0 0 100.414
+0.504545 1 0 0 0 100.505
+0.595455 1 0 0 0 100.595
+0.686364 1 0 0 0 100.686
+0.777273 1 0 0 0 100.777
+0.868182 1 0 0 0 100.868
+0.959091 1 0 0 0 100.959
+rank 1:
+   Solving mesh displacement system... 4 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-mesh_deformation_external_01_mpi/solution/solution-00003
+     Topography min/max:       -0.0075 m, 0.1 m
+
+*** Timestep 4:  t=0.002 seconds, dt=0.0005 seconds
+update()
+compute_updated_velocities_at_points()
+Solution at evaluation points:
+rank 0:
+0.05 1 0 0 0 100.05
+0.140909 1 0 0 0 100.141
+0.231818 1 0 0 0 100.232
+0.322727 1 0 0 0 100.323
+0.413636 1 0 0 0 100.414
+0.504545 1 0 0 0 100.505
+0.595455 1 0 0 0 100.595
+0.686364 1 0 0 0 100.686
+0.777273 1 0 0 0 100.777
+0.868182 1 0 0 0 100.868
+0.959091 1 0 0 0 100.959
+rank 1:
+   Solving mesh displacement system... 4 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-mesh_deformation_external_01_mpi/solution/solution-00004
+     Topography min/max:       -0.01 m, 0.1 m
+
+*** Timestep 5:  t=0.0025 seconds, dt=0.0005 seconds
+update()
+compute_updated_velocities_at_points()
+Solution at evaluation points:
+rank 0:
+0.05 1 0 0 0 100.05
+0.140909 1 0 0 0 100.141
+0.231818 1 0 0 0 100.232
+0.322727 1 0 0 0 100.323
+0.413636 1 0 0 0 100.414
+0.504545 1 0 0 0 100.505
+0.595455 1 0 0 0 100.595
+0.686364 1 0 0 0 100.686
+0.777273 1 0 0 0 100.777
+0.868182 1 0 0 0 100.868
+0.959091 1 0 0 0 100.959
+rank 1:
+   Solving mesh displacement system... 4 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-mesh_deformation_external_01_mpi/solution/solution-00005
+     Topography min/max:       -0.0125 m, 0.1 m
+
+*** Timestep 6:  t=0.003 seconds, dt=0.0005 seconds
+update()
+compute_updated_velocities_at_points()
+Solution at evaluation points:
+rank 0:
+0.05 1 0 0 0 100.05
+0.140909 1 0 0 0 100.141
+0.231818 1 0 0 0 100.232
+0.322727 1 0 0 0 100.323
+0.413636 1 0 0 0 100.414
+0.504545 1 0 0 0 100.505
+0.595455 1 0 0 0 100.595
+0.686364 1 0 0 0 100.686
+0.777273 1 0 0 0 100.777
+0.868182 1 0 0 0 100.868
+0.959091 1 0 0 0 100.959
+rank 1:
+   Solving mesh displacement system... 4 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-mesh_deformation_external_01_mpi/solution/solution-00006
+     Topography min/max:       -0.015 m, 0.1 m
+
+*** Timestep 7:  t=0.0035 seconds, dt=0.0005 seconds
+update()
+compute_updated_velocities_at_points()
+Solution at evaluation points:
+rank 0:
+0.05 1 0 0 0 100.05
+0.140909 1 0 0 0 100.141
+0.231818 1 0 0 0 100.232
+0.322727 1 0 0 0 100.323
+0.413636 1 0 0 0 100.414
+0.504545 1 0 0 0 100.505
+0.595455 1 0 0 0 100.595
+0.686364 1 0 0 0 100.686
+0.777273 1 0 0 0 100.777
+0.868182 1 0 0 0 100.868
+0.959091 1 0 0 0 100.959
+rank 1:
+   Solving mesh displacement system... 4 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-mesh_deformation_external_01_mpi/solution/solution-00007
+     Topography min/max:       -0.0175 m, 0.105 m
+
+*** Timestep 8:  t=0.004 seconds, dt=0.0005 seconds
+update()
+compute_updated_velocities_at_points()
+Solution at evaluation points:
+rank 0:
+0.05 1 0 0 0 100.05
+0.140909 1 0 0 0 100.141
+0.231818 1 0 0 0 100.232
+0.322727 1 0 0 0 100.323
+0.413636 1 0 0 0 100.414
+0.504545 1 0 0 0 100.505
+0.595455 1 0 0 0 100.595
+0.686364 1 0 0 0 100.686
+0.777273 1 0 0 0 100.777
+0.868182 1 0 0 0 100.868
+0.959091 1 0 0 0 100.959
+rank 1:
+   Solving mesh displacement system... 4 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-mesh_deformation_external_01_mpi/solution/solution-00008
+     Topography min/max:       -0.02 m, 0.12 m
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/mesh_deformation_external_01_mpi/statistics
+++ b/tests/mesh_deformation_external_01_mpi/statistics
@@ -1,0 +1,19 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of nonlinear iterations
+# 8: Visualization file name
+# 9: Minimum topography (m)
+# 10: Maximum topography (m)
+0 0.000000000000e+00 0.000000000000e+00 64 659 289 0 output-mesh_deformation_external_01_mpi/solution/solution-00000  0.00000000e+00 1.00000000e-01 
+1 5.000000000000e-04 5.000000000000e-04 64 659 289 0 output-mesh_deformation_external_01_mpi/solution/solution-00001 -2.50000000e-03 1.00000000e-01 
+2 1.000000000000e-03 5.000000000000e-04 64 659 289 0 output-mesh_deformation_external_01_mpi/solution/solution-00002 -5.00000000e-03 1.00000000e-01 
+3 1.500000000000e-03 5.000000000000e-04 64 659 289 0 output-mesh_deformation_external_01_mpi/solution/solution-00003 -7.50000000e-03 1.00000000e-01 
+4 2.000000000000e-03 5.000000000000e-04 64 659 289 0 output-mesh_deformation_external_01_mpi/solution/solution-00004 -1.00000000e-02 1.00000000e-01 
+5 2.500000000000e-03 5.000000000000e-04 64 659 289 0 output-mesh_deformation_external_01_mpi/solution/solution-00005 -1.25000000e-02 1.00000000e-01 
+6 3.000000000000e-03 5.000000000000e-04 64 659 289 0 output-mesh_deformation_external_01_mpi/solution/solution-00006 -1.50000000e-02 1.00000000e-01 
+7 3.500000000000e-03 5.000000000000e-04 64 659 289 0 output-mesh_deformation_external_01_mpi/solution/solution-00007 -1.75000000e-02 1.05000000e-01 
+8 4.000000000000e-03 5.000000000000e-04 64 659 289 0 output-mesh_deformation_external_01_mpi/solution/solution-00008 -2.00000000e-02 1.20000000e-01 


### PR DESCRIPTION
This is not particularly clean or efficient, but this should now support N to N parallel computations.

During the setup phase we:
1. Compute the local data and closest evaluation point for each DoF
2. Gather all this information on rank 0.
3. On rank 0, pick the closest evaluation point for each support point.
4. Send necessary information back to the owner of the evaluation point.

I don't think it is too much of an issue for now as the amount of data gathered is proportional to the number of surface DoFs and it only happens during setup.

One could optimize this better. For example, the DofToEvalPointData struct is now rather big and not all members are always in use. I wanted things to work first. :-)