### PR TITLE
Landlab: correctly support MPI on a subset

### DIFF
--- a/include/aspect/mesh_deformation/landlab.h
+++ b/include/aspect/mesh_deformation/landlab.h
@@ -97,6 +97,16 @@ namespace aspect
         unsigned int n_landlab_ranks;
 
         /**
+         * The MPI communicator for the Landlab simulation.
+         */
+        MPI_Comm landlab_communicator;
+
+        /**
+         * Whether this rank is one of the ranks that runs the Landlab simulation.
+         */
+        bool this_rank_runs_landlab;
+
+        /**
          * The path to the Landlab Python module.
          */
         std::string script_path;

--- a/source/mesh_deformation/landlab.cc
+++ b/source/mesh_deformation/landlab.cc
@@ -82,42 +82,48 @@ namespace aspect
                   ExcMessage("The surface diffusion mesh deformation plugin only works for Box geometries."));
 
       unsigned int rank = Utilities::MPI::this_mpi_process(this->get_mpi_communicator());
-      if (rank >= n_landlab_ranks)
-        return;
 
+      this_rank_runs_landlab = (rank < n_landlab_ranks);
+      const int color = this_rank_runs_landlab?1:0;
+      int ierr = MPI_Comm_split(this->get_mpi_communicator(), color, rank, &landlab_communicator);
+      AssertThrow(ierr == MPI_SUCCESS, ExcMessage("Failed to split MPI communicator for Landlab simulation"));
+
+      if (this_rank_runs_landlab)
+        {
 #ifdef ASPECT_WITH_PYTHON
-      // Append script dirs so env packages (venv site-packages, PYTHONPATH) are found first
-      // for "import landlab":
-      PyRun_SimpleString("import sys");
-      PyRun_SimpleString("sys.path.append(\"" ASPECT_SOURCE_DIR "/tests\")");
-      PyRun_SimpleString("sys.path.append(\".\")");
+          // Append script dirs so env packages (venv site-packages, PYTHONPATH) are found first
+          // for "import landlab":
+          PyRun_SimpleString("import sys");
+          PyRun_SimpleString("sys.path.append(\"" ASPECT_SOURCE_DIR "/tests\")");
+          PyRun_SimpleString("sys.path.append(\".\")");
 
-      // avoid floating point exceptions in Landlab Python code:
+          // avoid floating point exceptions in Landlab Python code:
 #ifdef ASPECT_USE_FP_EXCEPTIONS
-      fedisableexcept(FE_DIVBYZERO|FE_INVALID);
+          fedisableexcept(FE_DIVBYZERO|FE_INVALID);
 #endif
 
-      std::cout << "importing '" << script_module_name << "' ..." << std::endl;
-      pModule = PyImport_ImportModule(script_module_name.c_str());
-      if (PyErr_Occurred())
-        PyErr_Print();
-      AssertThrow(pModule, ExcMessage("Failed to load Python module"));
+          std::cout << "importing '" << script_module_name << "' ..." << std::endl;
+          pModule = PyImport_ImportModule(script_module_name.c_str());
+          if (PyErr_Occurred())
+            PyErr_Print();
+          AssertThrow(pModule, ExcMessage("Failed to load Python module"));
 
-      // Call Python initialize() function with communicator handle
-      PyObject *pArgs;
-      if (n_landlab_ranks == 1)
-        pArgs = PyTuple_Pack(1, Py_None);
-      else
-        pArgs = PyTuple_Pack(1, PyLong_FromLong(MPI_Comm_c2f(this->get_mpi_communicator())));
-      PyObject *pValue = call_python_function(pModule, "initialize", pArgs);
+          // Call Python initialize() function with communicator handle
+          PyObject *pArgs;
+          if (n_landlab_ranks == 1)
+            pArgs = PyTuple_Pack(1, Py_None);
+          else
+            pArgs = PyTuple_Pack(1, PyLong_FromLong(MPI_Comm_c2f(landlab_communicator)));
+          PyObject *pValue = call_python_function(pModule, "initialize", pArgs);
 
-      Py_DECREF(pArgs);
-      Py_DECREF(pValue);
+          Py_DECREF(pArgs);
+          Py_DECREF(pValue);
 
 #else
-      AssertThrow(false, ExcMessage("ASPECT needs to be configure with Python support "
-                                    "(ASPECT_WITH_PYTHON=ON in CMake) to be able to use the Landlab mesh deformation model."));
+          AssertThrow(false, ExcMessage("ASPECT needs to be configure with Python support "
+                                        "(ASPECT_WITH_PYTHON=ON in CMake) to be able to use the Landlab mesh deformation model."));
 #endif
+        }
     }
 
 
@@ -130,8 +136,7 @@ namespace aspect
 #ifdef ASPECT_WITH_PYTHON
       if (!this->remote_point_evaluator)
         {
-          unsigned int rank = Utilities::MPI::this_mpi_process(this->get_mpi_communicator());
-          if (rank >= n_landlab_ranks)
+          if (!this_rank_runs_landlab)
             {
               // This rank does not participate, so we don't own any evaluation points:
               std::vector<Point<dim>> surface_points;
@@ -200,7 +205,7 @@ namespace aspect
       Assert(current_solution_at_points.size() == this->evaluation_points.size(), ExcInternalError());
       std::vector<Tensor<1,dim>> velocities(current_solution_at_points.size(), Tensor<1,dim>());
 
-      if (pModule)
+      if (this_rank_runs_landlab)
         {
           // Build a dictionary with solution values for each variable to pass to Python:
           PyObject *pDict = PyDict_New();
@@ -282,7 +287,7 @@ namespace aspect
 
       // 1. Grab initial deformation from Landlab:
       std::vector<Tensor<1,dim>> initial_deformation(this->evaluation_points.size(), Tensor<1,dim>());
-      if (pModule)
+      if (this_rank_runs_landlab)
         {
           Tensor<1,dim> topography_direction;
           topography_direction[dim-1] = 1.0;
@@ -344,7 +349,8 @@ namespace aspect
         {
           prm.declare_entry("MPI ranks for Landlab", "1",
                             Patterns::Integer(1),
-                            "Number of ranks to use for the Landlab simulation. If set to 1, the Landlab simulation will run sequentially without MPI.");
+                            "Number of ranks to use for the Landlab simulation. If set to 1, the Landlab simulation will run sequentially "
+                            "without MPI. If set to -1, the Landlab simulation will run on all ranks.");
           prm.declare_entry("Script path", "",
                             Patterns::Anything(),
                             "Path to the Python script to execute. Relative paths and the placeholders "
@@ -371,7 +377,12 @@ namespace aspect
       {
         prm.enter_subsection ("Landlab");
         {
-          n_landlab_ranks = prm.get_integer("MPI ranks for Landlab");
+          const int ranks = prm.get_integer("MPI ranks for Landlab");
+          if (ranks == -1)
+            n_landlab_ranks = Utilities::MPI::n_mpi_processes(this->get_mpi_communicator());
+          else
+            n_landlab_ranks = ranks;
+
           script_path = prm.get("Script path");
           script_module_name = prm.get("Script name");
           script_argument = prm.get("Script argument");

--- a/tests/mesh_deformation_external_landlab_02.prm
+++ b/tests/mesh_deformation_external_landlab_02.prm
@@ -1,0 +1,102 @@
+# Test the "landlab" external mesh deformation making use of
+# the MPI settings. Note that we are not actually running
+# Landlab in parallel here.
+#
+# Enable if: ASPECT_WITH_PYTHON
+# MPI: 3
+
+set Dimension                              = 3
+set Use years instead of seconds           = false
+set End time                               = 0.001
+set Maximum time step                      = 0.0005
+set Nonlinear solver scheme = no Advection, no Stokes
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+    set Y extent = 1
+    set Z extent = 1
+  end
+end
+
+# Temperature effects are ignored
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Function expression = 100*x+y
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = bottom, top
+  set List of model names = initial temperature
+end
+
+# Free slip on all boundaries
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = left, right, bottom, top
+end
+
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: Landlab
+  set Additional tangential mesh velocity boundary indicators = left, right
+  subsection Landlab
+    set Script name = mesh_deformation_external_landlab_02
+    set MPI ranks for Landlab = 2
+  end
+end
+
+# Vertical gravity
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 1
+  end
+end
+
+# One material with unity properties
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 1
+    set Thermal expansion coefficient = 1
+    set Viscosity                     = 1
+  end
+end
+
+# We also have to specify that we want to use the Boussinesq
+# approximation (assuming the density in the temperature
+# equation to be constant, and incompressibility).
+subsection Formulation
+  set Formulation = Boussinesq approximation
+end
+
+# We here use a globally refined mesh without
+# adaptive mesh refinement.
+subsection Mesh refinement
+  set Initial global refinement                = 2
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization,  topography
+
+  subsection Visualization
+    set Time between graphical output = 0
+    set Output mesh velocity = true
+    set Output mesh displacement = true
+    set Output undeformed mesh = false
+    set Interpolate output = false
+  end
+end

--- a/tests/mesh_deformation_external_landlab_02.py
+++ b/tests/mesh_deformation_external_landlab_02.py
@@ -1,0 +1,96 @@
+print("mesh_deformation_external_landlab_02.py")
+
+from mpi4py import MPI
+import numpy as np
+
+current_time = 0
+
+comm = None
+
+
+px = None
+py = None
+elevation = None
+
+def initialize(comm_handle):
+    global px, py, elevation
+
+    if not comm_handle is None:
+        # Convert the handle back to an MPI communicator
+        global comm
+        comm = MPI.Comm.f2py(comm_handle)
+
+        rank = comm.Get_rank()
+        size = comm.Get_size()
+
+
+        data = 1
+        globalsum = comm.allreduce(data, op=MPI.SUM)
+        if comm.rank == 0:
+            print(f"Python: comm size = {size}, communication test = {globalsum}")
+    
+        if comm.rank == 0:
+            px = np.array([0.1, 0.3, 0.4])
+            py = np.array([0.2, 0.4, 0.5])
+
+        if comm.rank == 1:
+            px = np.array([0.5, 0.7])
+            py = np.array([0.6, 0.8])
+
+        elevation = np.zeros(px.size)
+
+def finalize():
+    pass
+
+
+# Run the Landlab simulation from the current time to end_time and return
+# the new topographic elevation (in m) at each local node.
+# dict_variable_name_to_value_in_nodes is a dictionary mapping variables
+# (x velocity, y velocity, temperature, etc.) to an array of values in each
+# node.
+def update_until(end_time, dict_variable_name_to_value_in_nodes):
+
+    print(f"update_until: end_time = {end_time}")
+   
+    return elevation
+
+def set_mesh_information(dict_grid_information):
+    pass
+
+# Return the x coordinates of the locally owned nodes on this
+# MPI rank. grid_id is always 0.
+def get_grid_x(grid_id):
+    global px
+    return px
+
+# Return the y coordinates of the locally owned nodes on this
+# MPI rank. grid_id is always 0.
+def get_grid_y(grid_id):
+    global py
+    return py
+
+# Return the initial topography at the start of the simulation
+# in each node.
+def get_initial_topography(grid_id):
+    global elevation
+    return elevation
+
+
+def write_output():
+    pass    
+
+if __name__ == "__main__":
+    comm = MPI.COMM_WORLD
+    initialize(MPI.Comm.py2f(comm))
+
+    set_mesh_information({})
+    print("grid coordinates:", get_grid_x(0), get_grid_y(0))
+
+    dt = 0.1
+    for n in range(3):
+        data = {}
+        data["x velocity"] = np.zeros(px.size)
+        data["y velocity"] = np.zeros(px.size)
+        data["z velocity"] = np.zeros(px.size)
+        update_until(n*dt, data)
+        write_output()

--- a/tests/mesh_deformation_external_landlab_02/screen-output
+++ b/tests/mesh_deformation_external_landlab_02/screen-output
@@ -1,0 +1,52 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+importing 'mesh_deformation_external_landlab_02' ...
+importing 'mesh_deformation_external_landlab_02' ...
+mesh_deformation_external_landlab_02.py
+mesh_deformation_external_landlab_02.py
+Python: comm size = 2, communication test = 2
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 64 (on 3 levels)
+Number of degrees of freedom: 3,041 (2,187+125+729)
+
+Number of mesh deformation degrees of freedom: 375
+   Solving mesh displacement system... 0 iterations.
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+update_until: end_time = 0.0
+update_until: end_time = 0.0
+   Solving mesh displacement system... 0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-mesh_deformation_external_landlab_02/solution/solution-00000
+     Topography min/max:       0 m, 0 m
+
+*** Timestep 1:  t=0.0005 seconds, dt=0.0005 seconds
+update_until: end_time = 0.0005
+update_until: end_time = 0.0005
+   Solving mesh displacement system... 0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-mesh_deformation_external_landlab_02/solution/solution-00001
+     Topography min/max:       0 m, 0 m
+
+*** Timestep 2:  t=0.001 seconds, dt=0.0005 seconds
+update_until: end_time = 0.001
+update_until: end_time = 0.001
+   Solving mesh displacement system... 0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-mesh_deformation_external_landlab_02/solution/solution-00002
+     Topography min/max:       0 m, 0 m
+
+Termination requested by criterion: end time
+
+
++---------------------------------------------+------------+------------+
++---------------------------------+-----------+------------+------------+
++---------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/mesh_deformation_external_landlab_02/statistics
+++ b/tests/mesh_deformation_external_landlab_02/statistics
@@ -1,0 +1,13 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of nonlinear iterations
+# 8: Visualization file name
+# 9: Minimum topography (m)
+# 10: Maximum topography (m)
+0 0.000000000000e+00 0.000000000000e+00 64 2312 729 0 output-mesh_deformation_external_landlab_02/solution/solution-00000 0.00000000e+00 0.00000000e+00 
+1 5.000000000000e-04 5.000000000000e-04 64 2312 729 0 output-mesh_deformation_external_landlab_02/solution/solution-00001 0.00000000e+00 0.00000000e+00 
+2 1.000000000000e-03 5.000000000000e-04 64 2312 729 0 output-mesh_deformation_external_landlab_02/solution/solution-00002 0.00000000e+00 0.00000000e+00 


### PR DESCRIPTION
We now split the MPI communicator and can run landlab on the first k of n ranks. Also make the code more obvious to know which MPI rank is active instead of relying on pModule being null.

FYI @bangerth