### PR TITLE
Support Spherical Geometries

### DIFF
--- a/cookbooks/landlab/2D-T-Models/T-Model-LandLab.py
+++ b/cookbooks/landlab/2D-T-Models/T-Model-LandLab.py
@@ -1,0 +1,206 @@
+
+from mpi4py import MPI
+import json
+import os
+import numpy as np
+import landlab
+from landlab.components import LinearDiffuser
+from landlab.components import FlowAccumulator
+from landlab.components import StreamPowerEroder
+
+from landlab.io.legacy_vtk import write_legacy_vtk
+
+current_time = 0
+
+comm = None
+
+model_grid = None
+elevation = None
+linear_diffuser = None
+flow_accumulator = None
+stream_power_eroder = None
+
+s2yr = 365.25 * 24 * 3600
+timestep = 0
+vtks = []
+
+def initialize(comm_handle):
+    if not comm_handle is None:
+        # Convert the handle back to an MPI communicator
+        global comm
+        comm = MPI.Comm.f2py(comm_handle)
+
+        rank = comm.Get_rank()
+        size = comm.Get_size()
+
+        print(f"Python: Hello from Rank {rank} of {size}")
+
+        data = 1
+        globalsum = comm.allreduce(data, op=MPI.SUM)
+        if comm.rank == 0:
+            print(f"\tPython: testing communication; sum {globalsum}")
+    else:
+        print("Python: running sequentially!")
+
+def finalize():
+    pass
+
+
+# Run the Landlab simulation from the current time to end_time and return
+# the new topographic elevation (in m) at each local node.
+# dict_variable_name_to_value_in_nodes is a dictionary mapping variables
+# (x velocity, y velocity, temperature, etc.) to an array of values in each
+# node.
+def update_until(end_time, dict_variable_name_to_value_in_nodes):
+    global current_time, elevation, linear_diffuser, flow_accumulator, stream_power_eroder, timestep
+
+    dt = end_time - current_time
+    timestep += 1
+
+    deposition_erosion = np.zeros(model_grid.number_of_nodes)
+
+    slice_x_velocity = dict_variable_name_to_value_in_nodes["x velocity"]
+    slice_y_velocity = dict_variable_name_to_value_in_nodes["y velocity"]
+    slice_z_velocity = dict_variable_name_to_value_in_nodes["z velocity"]
+
+    # In the current setup, the y_velocity vector is ONLY nonzero along y=0. We need
+    # to project the velocity outwards along all fixed values of y, assigning the same
+    # velocity to all nodes that share the same x value. 
+
+    # This code below first extract the velocities along y=0 (where they are correctly coming
+    # from ASPECT), then it finds all of the unique y values in the LandLab mesh, and then assigned
+    # the y=0 velocities to these y-values. This will only work for structured RasterGrids.
+
+    vertical_velocity = np.zeros(model_grid.number_of_nodes)
+    unique_x_values   = np.unique(model_grid.x_of_node)
+    for x in unique_x_values:
+        vertical_velocity[model_grid.x_of_node == x] = slice_y_velocity[unique_x_values == x]
+
+    # Substepping for surface processes
+    if dt>0:
+        n_substeps = 10
+        sub_dt = dt / n_substeps
+        for _ in range(n_substeps):
+
+          # TODO:
+          elevation_before = elevation.copy()
+
+          flow_accumulator.run_one_step()
+          stream_power_eroder.run_one_step(sub_dt)
+          linear_diffuser.run_one_step(sub_dt)
+
+          elevation += vertical_velocity * sub_dt
+
+          deposition_erosion += elevation - elevation_before
+        pass
+
+    filename = f"./output-2D-T-MODELS/landlab_{str(timestep).zfill(3)}.vtk"
+    print("Writing output VTK file...", filename)
+    vtk_file = write_legacy_vtk(path=filename, grid=model_grid, clobber=True, z_at_node=elevation)
+    
+    vtks.append((current_time, filename))
+
+    if True:
+        # write vtk.series file (ParaView supports legacy VTK in this format)
+        with open("./output-2D-T-MODELS/landlab.vtk.series", "w") as f:
+            series = {
+                "file-series-version": "1.0",
+                "files": [
+                    {"name": os.path.basename(filename), "time": time / s2yr}
+                    for time, filename in vtks
+                ]
+            }
+            json.dump(series, f, indent=2)
+
+    current_time = end_time
+    print("Max elevation:", np.max(elevation), "Min elevation:", np.min(elevation))
+
+    # This setup does not do any averaging of the topography across the LandLab mesh before returning
+    # the change in elevation used to deform the ASPECT mesh. Averaging will be straight forward to 
+    # do going forward, but for the purposes of this test I want to make sure the ASPECT mesh is
+    # deforming to the exact same topography as the LandLab mesh where they intersect.  
+
+    deposition_erosion_2d = np.zeros(len(np.unique(model_grid.x_of_node)))
+    for x in unique_x_values:
+        # deposition_erosion_2d[unique_x_values == x] = np.average(deposition_erosion[model_grid.x_of_node == x])
+        deposition_erosion_2d = deposition_erosion[model_grid.y_of_node == 0]
+    
+    return deposition_erosion_2d
+
+def set_mesh_information(dict_grid_information):
+    global model_grid, elevation
+
+    if not model_grid:
+        print("* Creating RasterModelGrid ...")
+        x_extent = dict_grid_information["Mesh X extent"]
+        y_extent = dict_grid_information["Mesh Y extent"]
+        spacing = dict_grid_information["Mesh Spacing"]
+
+        nrows = int(y_extent / spacing) + 1  # number of node rows
+        ncols = int(x_extent / spacing) + 1  # number of node columns
+
+        # For 2D models, shift the LandLab mesh so that it is centered on the y-axis.
+        model_grid = landlab.RasterModelGrid((nrows, ncols), xy_spacing=(spacing, spacing), xy_of_lower_left=(0, -y_extent / 2))
+
+        model_grid.set_closed_boundaries_at_grid_edges(right_is_closed=True, 
+                                                       left_is_closed=False, 
+                                                       top_is_closed=True, 
+                                                       bottom_is_closed=True)
+
+        print("* Creating topographic elevation ...")
+        # Initialize topography array with zeros
+        elevation = model_grid.add_zeros("topographic__elevation", at="node")
+        # Assign 1000 m high topography with random noise
+        np.random.seed(0)  # For reproducibility
+        elevation += 1000 + np.random.rand(model_grid.number_of_nodes)
+
+        print("* Done")
+
+# Return the x coordinates of the locally owned nodes on this
+# MPI rank. grid_id is always 0.
+def get_grid_x(grid_dictionary):
+    global model_grid
+    dim = grid_dictionary["ASPECT Dimension"]
+    if dim == 2:
+        print(np.unique(model_grid.x_of_node))
+        return  np.unique(model_grid.x_of_node)
+    if dim == 3:
+        return model_grid.x_of_node
+
+# Return the y coordinates of the locally owned nodes on this
+# MPI rank. grid_id is always 0.
+def get_grid_y(grid_dictionary):
+    global model_grid
+    dim = grid_dictionary["ASPECT Dimension"]
+    if dim == 2:
+        print(np.zeros(np.unique(model_grid.x_of_node).shape))
+        return np.zeros(np.unique(model_grid.x_of_node).shape)
+    if dim == 3:
+        return model_grid.y_of_node
+
+def initialize_landlab_components(landlab_component_parameters):
+    global model_grid, elevation, linear_diffuser, flow_accumulator, stream_power_eroder
+
+    D    = landlab_component_parameters["Hillslope coefficient"]
+    K_sp = landlab_component_parameters["Stream power erodibility coefficient"]
+    flow_director = "D8" # Only flow director supported for HexGrids
+
+
+    print("* Creating LinearDiffuser ... with D =", D)
+    linear_diffuser = LinearDiffuser(model_grid, linear_diffusivity=D)
+    print("* Creating FlowAccumulator ... with flow director =", flow_director)
+    flow_accumulator = FlowAccumulator(model_grid, elevation, flow_director=flow_director)
+    print("* Creating StreamPowerEroder ... with K_sp =", K_sp)
+    stream_power_eroder = StreamPowerEroder(model_grid, K_sp=K_sp)
+
+    pass
+# Return the initial topography at the start of the simulation
+# in each node.
+def get_initial_topography(grid_dictionary):
+    global elevation
+    dim = grid_dictionary["ASPECT Dimension"]
+    if dim == 2:
+        return elevation[model_grid.y_of_node == 0]
+    if dim == 3:
+        return elevation
+

--- a/cookbooks/landlab/2D-T-Models/simple_2D.prm
+++ b/cookbooks/landlab/2D-T-Models/simple_2D.prm
@@ -1,0 +1,138 @@
+# This parameter file sets up a model to test the interfacing between
+# the surface processes code LandLab and ASPECT. The ASPECT model is a 2D
+# vertical slice model, and the LandLab model is a 2D horizontal surface model.
+# This model tests that the interfacing between LandLab and ASPECT performs
+# correctly in this 2D, "T-Model" configuration. The ASPECT mesh and the LandLab
+# mesh are the same resolution, and since there is no averaging of topography
+# on the LandLab side, the topography should exactly match where the two models
+# intersect.
+set Dimension                              = 2
+
+
+set Use years instead of seconds           = true
+set End time                               = 1000e3
+set Maximum time step                      = 10e3
+
+
+set Nonlinear solver scheme                = single Advection, single Stokes
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+set Output directory                       = output-2D-T-MODELS
+
+# 2.5 km mesh for ASPECT
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+
+    set X extent = 100e3
+    set Y extent = 100e3
+
+    set X repetitions = 40
+    set Y repetitions = 40
+
+  end
+end
+
+# Temperature effects are ignored
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = bottom, top
+  set List of model names = initial temperature
+end
+
+# Free slip on all boundaries
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = left: function, right: function, bottom: function
+  subsection Function
+    set Coordinate system   =  cartesian
+    set Variable names      = x, y
+    set Function constants  = uplift=0.01
+    set Function expression = 0; x * uplift / 100e3
+  end
+end
+
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: Landlab
+  set Additional tangential mesh velocity boundary indicators = left, right
+
+  subsection Landlab
+    set MPI ranks for Landlab = 1
+    set Script name           = T-Model-LandLab
+    set Script argument       =
+    set Script path           =
+
+    set Hillslope diffusion coefficient       = 1e-4
+    set Stream power erodibility coefficient  = 1e-5
+    set Define LandLab parameters using years = true
+
+    # 2.5 km mesh for LandLab.
+    subsection Mesh information
+      set X extent = 102.5e3
+      set Y extent = 100e3
+      set Spacing  = 2500
+    end
+  end
+end
+
+# Vertical gravity
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 0
+  end
+end
+
+# One material with unity properties
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 1
+    set Thermal expansion coefficient = 0
+    set Viscosity                     = 1
+  end
+end
+
+# We also have to specify that we want to use the Boussinesq
+# approximation (assuming the density in the temperature
+# equation to be constant, and incompressibility).
+subsection Formulation
+  set Formulation = Boussinesq approximation
+end
+
+# We here use a globally refined mesh without
+# adaptive mesh refinement.
+subsection Mesh refinement
+  set Initial global refinement                = 0
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, topography, velocity statistics
+
+  subsection Topography
+    set Output to file = true
+    set Time between text output = 50e3
+  end
+
+  subsection Visualization
+    set Time between graphical output = 50e3
+    set Output mesh velocity = true
+    set Output mesh displacement = true
+    set Output undeformed mesh = false
+    set Interpolate output = false
+  end
+
+end

--- a/cookbooks/landlab/coupled2/lateral_advection.prm
+++ b/cookbooks/landlab/coupled2/lateral_advection.prm
@@ -1,0 +1,138 @@
+# This parameter file sets up a model to test the lateral advection of the
+# surface when coupling LandLab and ASPECT. The model begins with an initial
+# gaussian topogaphy (defined in LandLab) in the model of the ASPECT model.
+# The ASPECT velocity boundary conditions are set to first move in the positive
+# x direction for 1 Myr, and then in the positive y direction for 1 Myr. The velocity
+# of the ASPECT model is sent to LandLab where it advects the topography, which is then
+# reflected in ASPECT.
+set Dimension                              = 3
+
+
+set Use years instead of seconds           = true
+set End time                               = 2000e3
+set Maximum time step                      = 25e3
+
+
+set Nonlinear solver scheme                = single Advection, single Stokes
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+set Output directory                       = output-LATERAL-ADVECTION
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+
+    set Box origin X coordinate = 1e3
+    set Box origin Y coordinate = 1e3
+    set X extent = 100e3
+    set Y extent = 100e3
+    set Z extent = 20e3
+
+    set X repetitions = 20
+    set Y repetitions = 20
+    set Z repetitions = 4
+  end
+end
+
+# Temperature effects are ignored
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = bottom, top
+  set List of model names = initial temperature
+end
+
+# Free slip on all boundaries
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = left: function, right: function, front: function, back: function, bottom: function
+  subsection Function
+    set Coordinate system =  cartesian
+    set Variable names = x, y, z, t
+    set Function constants  = uplift=0.0, t_cutoff=1000e3
+    set Function expression = if(t<t_cutoff, 0.02, 0); if(t<t_cutoff, 0, 0.02); uplift
+  end
+end
+
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: Landlab
+  set Additional tangential mesh velocity boundary indicators = left, right, front, back
+
+  subsection Landlab
+    set MPI ranks for Landlab = 1
+    set Script name           = lateral_advection
+    set Script argument       =
+    set Script path           =
+
+    set Hillslope diffusion coefficient       = 1e-4
+    set Stream power erodibility coefficient  = 5e-5
+    set Define LandLab parameters using years = true
+
+    subsection Mesh information
+      set X extent = 102e3
+      set Y extent = 102e3
+      set Spacing  = 500
+    end
+  end
+end
+
+# Vertical gravity
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 0
+  end
+end
+
+# One material with unity properties
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 1
+    set Thermal expansion coefficient = 0
+    set Viscosity                     = 1
+  end
+end
+
+# We also have to specify that we want to use the Boussinesq
+# approximation (assuming the density in the temperature
+# equation to be constant, and incompressibility).
+subsection Formulation
+  set Formulation = Boussinesq approximation
+end
+
+# We here use a globally refined mesh without
+# adaptive mesh refinement.
+subsection Mesh refinement
+  set Initial global refinement                = 0
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, topography, velocity statistics
+
+  subsection Topography
+    set Output to file = true
+    set Time between text output = 50e3
+  end
+
+  subsection Visualization
+    set Time between graphical output = 50e3
+    set Output mesh velocity = true
+    set Output mesh displacement = true
+    set Output undeformed mesh = false
+    set Interpolate output = false
+  end
+
+end

--- a/cookbooks/landlab/coupled2/lateral_advection.py
+++ b/cookbooks/landlab/coupled2/lateral_advection.py
@@ -1,0 +1,181 @@
+
+from mpi4py import MPI
+import json
+import os
+import numpy as np
+import landlab
+from landlab.components import AdvectionSolverTVD
+
+from landlab.io.legacy_vtk import write_legacy_vtk
+
+current_time = 0
+
+comm = None
+
+model_grid = None
+elevation = None
+surface_advector = None
+horizontal_velocity = None
+ux = None
+uy = None
+
+timestep = 0
+vtks = []
+
+def initialize(comm_handle):
+    if not comm_handle is None:
+        # Convert the handle back to an MPI communicator
+        global comm
+        comm = MPI.Comm.f2py(comm_handle)
+
+        rank = comm.Get_rank()
+        size = comm.Get_size()
+
+        print(f"Python: Hello from Rank {rank} of {size}")
+
+        data = 1
+        globalsum = comm.allreduce(data, op=MPI.SUM)
+        if comm.rank == 0:
+            print(f"\tPython: testing communication; sum {globalsum}")
+    else:
+        print("Python: running sequentially!")
+
+def finalize():
+    pass
+
+
+# Run the Landlab simulation from the current time to end_time and return
+# the new topographic elevation (in m) at each local node.
+# dict_variable_name_to_value_in_nodes is a dictionary mapping variables
+# (x velocity, y velocity, temperature, etc.) to an array of values in each
+# node.
+def update_until(end_time, dict_variable_name_to_value_in_nodes):
+    global current_time, elevation, surface_advector, horizontal_velocity, ux, uy, timestep
+    dt = end_time - current_time
+    timestep += 1
+
+    deposition_erosion = np.zeros(model_grid.number_of_nodes)
+
+    x_velocity = dict_variable_name_to_value_in_nodes["x velocity"]
+    y_velocity = dict_variable_name_to_value_in_nodes["y velocity"]
+    z_velocity = dict_variable_name_to_value_in_nodes["z velocity"]
+
+    # The x, y, z velocities passed in from ASPECT are defined at the node points of the LandLab mesh.
+    # However, lateral advection of the LandLab surface requires that the velocity is defined at the links.
+    # To do this, we determine the average value of the x,y velocity at the link using the node points that 
+    # are connected by the link. Then, we can use AdvectionSolverTVD to advect the surface.
+
+    x_vel_at_links = model_grid.map_mean_of_link_nodes_to_link(x_velocity)
+    y_vel_at_links = model_grid.map_mean_of_link_nodes_to_link(y_velocity)
+
+    horizontal_velocity[model_grid.horizontal_links] = x_vel_at_links[model_grid.horizontal_links]
+    horizontal_velocity[model_grid.vertical_links]   = y_vel_at_links[model_grid.vertical_links]
+    surface_advector = AdvectionSolverTVD(model_grid, fields_to_advect=elevation)
+
+    # Substepping for surface processes
+    if dt>0:
+        n_substeps = 10
+        sub_dt = dt / n_substeps
+        for _ in range(n_substeps):
+
+          # TODO:
+          elevation_before = elevation.copy()
+
+          # Uplift the topography using the ASPECT vertical velocity.
+          elevation[model_grid.core_nodes] += z_velocity[model_grid.core_nodes] * sub_dt
+
+          # Advect the grid with the horizontal velocity from ASPECT. The ASPECT velocities are already being passed
+          # correctly at each NODE point of the landlab grid. However, the TVDAdvector requires the velocity at the LINKS.
+          # There must be a relationship between the two that can be leveraged, but at the moment I'm not sure how.
+          surface_advector.update(sub_dt)
+
+          deposition_erosion += elevation - elevation_before
+
+    current_time = end_time
+
+    # filename = f"./output/landlab_{str(timestep).zfill(3)}.vtk"
+    # print("Writing output VTK file...", filename)
+    # vtk_file = write_legacy_vtk(path=filename, grid=model_grid, clobber=True)
+    # vtks.append((current_time, filename))
+
+    # if True:
+    #     # write vtk.series file (ParaView supports legacy VTK in this format)
+    #     with open("./output/landlab.vtk.series", "w") as f:
+    #         series = {
+    #             "file-series-version": "1.0",
+    #             "files": [
+    #                 {"name": os.path.basename(filename), "time": time}
+    #                 for time, filename in vtks
+    #             ]
+    #         }
+    #         json.dump(series, f, indent=2)
+    
+    # print ("deposition/erosion:", np.linalg.norm(deposition_erosion))
+    print("Max elevation:", np.max(elevation), "Min elevation:", np.min(elevation))
+    # print("Max elevation:", np.max(deposition_erosion), "Min elevation:", np.min(deposition_erosion))
+
+    return deposition_erosion
+    # return elevation
+
+def set_mesh_information(dict_grid_information):
+    global model_grid, elevation, horizontal_velocity, ux, uy
+
+    if not model_grid:
+        print("* Creating RasterModelGrid ...")
+        x_extent = dict_grid_information["Mesh X extent"]
+        y_extent = dict_grid_information["Mesh Y extent"]
+        spacing = dict_grid_information["Mesh Spacing"]
+
+        nrows = int(y_extent / spacing)  # number of node rows
+        ncols = int(x_extent / spacing)  # number of node columns
+
+        model_grid = landlab.RasterModelGrid((nrows, ncols), xy_spacing=(spacing, spacing))
+        model_grid.set_closed_boundaries_at_grid_edges(True, True, True, True)
+
+        print("* Creating topographic elevation ...")
+        # Initialize topography array with zeros
+        elevation = model_grid.add_zeros("topographic__elevation", at="node")
+
+        # create a Gaussian hill in the center of the domain
+        gaussian_height = 5e3
+        x_extent = model_grid.x_of_node.max() - model_grid.x_of_node.min()
+        y_extent = model_grid.y_of_node.max() - model_grid.y_of_node.min()
+        elevation += gaussian_height * np.exp(-((model_grid.node_x - x_extent/2)**2 + (model_grid.node_y - y_extent/2)**2) / (2 * (10e3)**2))
+
+        # Initialize the horizontal velocity so that we can pass the ASPECT velocities to it later.
+        horizontal_velocity = model_grid.add_zeros("advection__velocity", at="link")
+
+        ux = model_grid.add_zeros("x_velocity", at="node")
+        uy = model_grid.add_zeros("y_velocity", at="node")
+        print("\tnumber of nodes:", model_grid.number_of_nodes)
+
+        print("* Done")
+
+# Return the x coordinates of the locally owned nodes on this
+# MPI rank. grid_id is always 0.
+def get_grid_x(grid_id):
+    global model_grid
+    return model_grid.node_x
+
+# Return the y coordinates of the locally owned nodes on this
+# MPI rank. grid_id is always 0.
+def get_grid_y(grid_id):
+    global model_grid
+    return model_grid.node_y
+
+def initialize_landlab_components(landlab_component_parameters):
+    global model_grid, elevation
+
+    pass
+
+# Return the initial topography at the start of the simulation
+# in each node.
+def get_initial_topography(grid_id):
+    global elevation
+    return elevation
+
+
+def write_output(timestep):
+    # Write the grid to vtk
+    print("Writing output VTK file...")
+    vtk_file = write_legacy_vtk(path=f"./output_{str(timestep).zfill(3)}.vtk", grid=model_grid, clobber=True)

--- a/cookbooks/landlab/coupled2/vertical_advection.prm
+++ b/cookbooks/landlab/coupled2/vertical_advection.prm
@@ -1,0 +1,136 @@
+# This parameter file sets up a model to test the interfacing between
+# the surface processes code LandLab and ASPECT. The model prescribes
+# uniform uplift within the ASPECT model (1 cm/yr), which is then used
+# to uplift the LandLab model. The LandLab model erodes the topography
+# using Hillslope Diffusion and Stream power.
+set Dimension                              = 3
+
+
+set Use years instead of seconds           = true
+set End time                               = 2e6
+set Maximum time step                      = 10e3
+
+
+set Nonlinear solver scheme                = single Advection, single Stokes
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+set Output directory                       = output-VERTICAL-ADVECTION
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+
+    set Box origin X coordinate = 1e3
+    set Box origin Y coordinate = 1e3
+    set X extent = 100e3
+    set Y extent = 100e3
+    set Z extent = 20e3
+
+    set X repetitions = 20
+    set Y repetitions = 20
+    set Z repetitions = 4
+  end
+end
+
+# Temperature effects are ignored
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = bottom, top
+  set List of model names = initial temperature
+end
+
+# Free slip on all boundaries
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = left: function, right: function, front: function, back: function, bottom: function
+  subsection Function
+    set Coordinate system =  cartesian
+    set Variable names = x, y, z
+    set Function constants  = uplift=0.01
+    set Function expression = 0; 0; uplift
+  end
+end
+
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: Landlab
+  set Additional tangential mesh velocity boundary indicators = left, right, front, back
+
+  subsection Landlab
+    set MPI ranks for Landlab = 1
+    set Script name           = vertical_advection
+    set Script argument       =
+    set Script path           =
+
+    set Hillslope diffusion coefficient       = 1e-4
+    set Stream power erodibility coefficient  = 1e-5
+    set Define LandLab parameters using years = true
+
+    subsection Mesh information
+      set X extent = 102e3
+      set Y extent = 102e3
+      set Spacing  = 500
+    end
+  end
+end
+
+# Vertical gravity
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 0
+  end
+end
+
+# One material with unity properties
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 1
+    set Thermal expansion coefficient = 0
+    set Viscosity                     = 1
+  end
+end
+
+# We also have to specify that we want to use the Boussinesq
+# approximation (assuming the density in the temperature
+# equation to be constant, and incompressibility).
+subsection Formulation
+  set Formulation = Boussinesq approximation
+end
+
+# We here use a globally refined mesh without
+# adaptive mesh refinement.
+subsection Mesh refinement
+  set Initial global refinement                = 0
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, topography, velocity statistics
+
+  subsection Topography
+    set Output to file = true
+    set Time between text output = 50e3
+  end
+
+  subsection Visualization
+    set Time between graphical output = 50e3
+    set Output mesh velocity = true
+    set Output mesh displacement = true
+    set Output undeformed mesh = false
+    set Interpolate output = false
+  end
+
+end

--- a/cookbooks/landlab/coupled2/vertical_advection.py
+++ b/cookbooks/landlab/coupled2/vertical_advection.py
@@ -1,0 +1,179 @@
+
+from mpi4py import MPI
+import json
+import os
+import numpy as np
+import landlab
+from landlab.components import LinearDiffuser
+from landlab.components import FlowAccumulator
+from landlab.components import StreamPowerEroder
+
+from landlab.io.legacy_vtk import write_legacy_vtk
+
+current_time = 0
+
+comm = None
+
+model_grid = None
+elevation = None
+linear_diffuser = None
+flow_accumulator = None
+stream_power_eroder = None
+
+timestep = 0
+vtks = []
+
+def initialize(comm_handle):
+    if not comm_handle is None:
+        # Convert the handle back to an MPI communicator
+        global comm
+        comm = MPI.Comm.f2py(comm_handle)
+
+        rank = comm.Get_rank()
+        size = comm.Get_size()
+
+        print(f"Python: Hello from Rank {rank} of {size}")
+
+        data = 1
+        globalsum = comm.allreduce(data, op=MPI.SUM)
+        if comm.rank == 0:
+            print(f"\tPython: testing communication; sum {globalsum}")
+    else:
+        print("Python: running sequentially!")
+
+def finalize():
+    pass
+
+
+# Run the Landlab simulation from the current time to end_time and return
+# the new topographic elevation (in m) at each local node.
+# dict_variable_name_to_value_in_nodes is a dictionary mapping variables
+# (x velocity, y velocity, temperature, etc.) to an array of values in each
+# node.
+def update_until(end_time, dict_variable_name_to_value_in_nodes):
+    global current_time, elevation, linear_diffuser, flow_accumulator, stream_power_eroder, timestep
+    dt = end_time - current_time
+    timestep += 1
+
+    deposition_erosion = np.zeros(model_grid.number_of_nodes)
+
+    x_velocity = dict_variable_name_to_value_in_nodes["x velocity"]
+    y_velocity = dict_variable_name_to_value_in_nodes["y velocity"]
+    z_velocity = dict_variable_name_to_value_in_nodes["z velocity"]
+
+    # Substepping for surface processes
+    if dt>0:
+        n_substeps = 10
+        sub_dt = dt / n_substeps
+        for _ in range(n_substeps):
+
+          # TODO:
+          elevation_before = elevation.copy()
+
+          # Run the landlab components: First route the water, use stream power to erode based on
+          # the routing of the water, then diffuse the topography
+          flow_accumulator.run_one_step()
+          stream_power_eroder.run_one_step(sub_dt)
+          linear_diffuser.run_one_step(sub_dt)
+
+          # Uplift the topography using the ASPECT vertical velocity.
+          elevation[model_grid.core_nodes] += z_velocity[model_grid.core_nodes] * sub_dt
+
+          # Advect the grid with the horizontal velocity from ASPECT. The ASPECT velocities are already being passed
+          # correctly at each NODE point of the landlab grid. However, the TVDAdvector requires the velocity at the LINKS.
+          # There must be a relationship between the two that can be leveraged, but at the moment I'm not sure how.
+
+          deposition_erosion += elevation - elevation_before
+        pass
+
+    current_time = end_time
+
+    # filename = f"./output/landlab_{str(timestep).zfill(3)}.vtk"
+    # print("Writing output VTK file...", filename)
+    # vtk_file = write_legacy_vtk(path=filename, grid=model_grid, clobber=True)
+    # vtks.append((current_time, filename))
+
+    # if True:
+    #     # write vtk.series file (ParaView supports legacy VTK in this format)
+    #     with open("./output/landlab.vtk.series", "w") as f:
+    #         series = {
+    #             "file-series-version": "1.0",
+    #             "files": [
+    #                 {"name": os.path.basename(filename), "time": time}
+    #                 for time, filename in vtks
+    #             ]
+    #         }
+    #         json.dump(series, f, indent=2)
+    
+    # print ("deposition/erosion:", np.linalg.norm(deposition_erosion))
+    print("Max elevation:", np.max(elevation), "Min elevation:", np.min(elevation))
+    # print("Max elevation:", np.max(deposition_erosion), "Min elevation:", np.min(deposition_erosion))
+
+    return deposition_erosion
+    # return elevation
+
+def set_mesh_information(dict_grid_information):
+    global model_grid, elevation
+
+    if not model_grid:
+        print("* Creating RasterModelGrid ...")
+        x_extent = dict_grid_information["Mesh X extent"]
+        y_extent = dict_grid_information["Mesh Y extent"]
+        spacing = dict_grid_information["Mesh Spacing"]
+
+        nrows = int(y_extent / spacing)  # number of node rows
+        ncols = int(x_extent / spacing)  # number of node columns
+
+        model_grid = landlab.RasterModelGrid((nrows, ncols), xy_spacing=(spacing, spacing))
+        model_grid.set_closed_boundaries_at_grid_edges(True, True, False, False)
+
+        print("* Creating topographic elevation ...")
+        # Initialize topography array with zeros
+        elevation = model_grid.add_zeros("topographic__elevation", at="node")
+        # Assign 1000 m high topography with random noise
+        np.random.seed(0)  # For reproducibility
+        elevation += np.random.rand(model_grid.number_of_nodes) / 1000.0
+
+        print("\tnumber of nodes:", model_grid.number_of_nodes)
+
+        print("* Done")
+
+# Return the x coordinates of the locally owned nodes on this
+# MPI rank. grid_id is always 0.
+def get_grid_x(grid_id):
+    global model_grid
+    return model_grid.node_x
+
+# Return the y coordinates of the locally owned nodes on this
+# MPI rank. grid_id is always 0.
+def get_grid_y(grid_id):
+    global model_grid
+    return model_grid.node_y
+
+def initialize_landlab_components(landlab_component_parameters):
+    global model_grid, elevation, linear_diffuser, flow_accumulator, stream_power_eroder, uplift_rate
+
+    D    = landlab_component_parameters["Hillslope coefficient"]
+    K_sp = landlab_component_parameters["Stream power erodibility coefficient"]
+    flow_director = "D8" # Only flow director supported for HexGrids
+
+
+    print("* Creating LinearDiffuser ... with D =", D)
+    linear_diffuser = LinearDiffuser(model_grid, linear_diffusivity=D)
+    print("* Creating FlowAccumulator ... with flow director =", flow_director)
+    flow_accumulator = FlowAccumulator(model_grid, elevation, flow_director=flow_director)
+    print("* Creating StreamPowerEroder ... with K_sp =", K_sp)
+    stream_power_eroder = StreamPowerEroder(model_grid, K_sp=K_sp)
+
+    pass
+# Return the initial topography at the start of the simulation
+# in each node.
+def get_initial_topography(grid_id):
+    global elevation
+    return elevation
+
+
+def write_output(timestep):
+    # Write the grid to vtk
+    print("Writing output VTK file...")
+    vtk_file = write_legacy_vtk(path=f"./output_{str(timestep).zfill(3)}.vtk", grid=model_grid, clobber=True)

--- a/include/aspect/mesh_deformation/landlab.h
+++ b/include/aspect/mesh_deformation/landlab.h
@@ -111,6 +111,13 @@ namespace aspect
          */
         std::string script_argument;
 
+        double landlab_x_extent;
+        double landlab_y_extent;
+        double landlab_spacing;
+       
+        double hillslope_diffusion_coefficient;
+        double stream_power_erodibility_coefficient;
+        bool parameters_in_years;
 #ifdef ASPECT_WITH_PYTHON
         /**
          * The Python module object.

--- a/include/aspect/mesh_deformation/landlab.h
+++ b/include/aspect/mesh_deformation/landlab.h
@@ -114,7 +114,6 @@ namespace aspect
         double landlab_x_extent;
         double landlab_y_extent;
         double landlab_spacing;
-
         double hillslope_diffusion_coefficient;
         double stream_power_erodibility_coefficient;
         bool parameters_in_years;

--- a/include/aspect/mesh_deformation/landlab.h
+++ b/include/aspect/mesh_deformation/landlab.h
@@ -114,7 +114,7 @@ namespace aspect
         double landlab_x_extent;
         double landlab_y_extent;
         double landlab_spacing;
-       
+
         double hillslope_diffusion_coefficient;
         double stream_power_erodibility_coefficient;
         bool parameters_in_years;

--- a/include/aspect/mesh_deformation/landlab.h
+++ b/include/aspect/mesh_deformation/landlab.h
@@ -117,6 +117,8 @@ namespace aspect
         double hillslope_diffusion_coefficient;
         double stream_power_erodibility_coefficient;
         bool parameters_in_years;
+
+        bool is_spherical;
 #ifdef ASPECT_WITH_PYTHON
         /**
          * The Python module object.

--- a/source/mesh_deformation/external_tool_interface.cc
+++ b/source/mesh_deformation/external_tool_interface.cc
@@ -42,8 +42,9 @@ namespace aspect
                                              AffineConstraints<double> &mesh_velocity_constraints,
                                              const std::set<types::boundary_id> &boundary_ids) const
     {
-      // First compute a (global) vector that has the correct velocities
-      // set at all boundary nodes:
+      // First compute a (global) vector that has the correct velocities set at all boundary nodes.
+      // This takes the points on the LandLab mesh (which are the evaluation points) and interpolates
+      // the solution from ASPECT onto these evaluation points.
       const std::vector<std::vector<double>> aspect_surface_velocities = evaluate_aspect_variables_at_points();
 
       const std::vector<Tensor<1,dim>> external_surface_velocities

--- a/source/mesh_deformation/landlab.cc
+++ b/source/mesh_deformation/landlab.cc
@@ -228,6 +228,9 @@ namespace aspect
       Assert(current_solution_at_points.size() == this->evaluation_points.size(), ExcInternalError());
       std::vector<Tensor<1,dim>> velocities(current_solution_at_points.size(), Tensor<1,dim>());
 
+      // What seems to be happening here is that we check if the python script has been loaded/exists. If it does,
+      // we enter this block. In this block, a python dictionary is made which contains the variables that are 
+      // to be passed over to LandLab. 
       if (pModule)
         {
           // Build a dictionary with solution values for each variable to pass to Python:
@@ -243,6 +246,7 @@ namespace aspect
               for (unsigned int j=0; j<current_solution_at_points.size(); ++j)
                 {
                   variable_data[i][j] = current_solution_at_points[j][i];
+                  // std::cout << this->evaluation_points[j] << ": " << variable_names[i] << " = " << variable_data[i][j] << std::endl;
                 }
             }
           for (unsigned int i=0; i<variable_names.size(); ++i)
@@ -254,7 +258,7 @@ namespace aspect
           // Call update_until(). update_until() returns deposition_erosion. This is what eventually
           // gets converted to velocities to deform the ASPECT mesh.
           PyObject *pArgs = PyTuple_Pack(2, PyFloat_FromDouble(this->get_time()), pDict);
-          PyObject *pValue = call_python_function(pModule, "update_until", pArgs);
+          PyObject *pValue = call_python_function(pModule, "update_until", pArgs); // This line calls the landlab function
           Py_DECREF(pDict);
           Py_DECREF(pArgs);
 

--- a/source/mesh_deformation/landlab.cc
+++ b/source/mesh_deformation/landlab.cc
@@ -24,7 +24,9 @@
 #include <deal.II/base/patterns.h>
 
 #include <aspect/gravity_model/interface.h>
-#include <aspect/geometry_model/box.h>
+#include <aspect/geometry_model/chunk.h>
+#include <aspect/geometry_model/sphere.h>
+#include <aspect/geometry_model/spherical_shell.h>
 #include <deal.II/base/array_view.h>
 
 #include <cfenv>
@@ -78,8 +80,16 @@ namespace aspect
     void
     Landlab<dim>::initialize ()
     {
-      AssertThrow(Plugins::plugin_type_matches<GeometryModel::Box<dim>>(this->get_geometry_model()),
-                  ExcMessage("The surface diffusion mesh deformation plugin only works for Box geometries."));
+      // AssertThrow(Plugins::plugin_type_matches<GeometryModel::Box<dim>>(this->get_geometry_model()),
+      //             ExcMessage("The surface diffusion mesh deformation plugin only works for Box geometries."));
+
+      // Determine whether we are in a spherical geometry or not, which affects how we interpret the coordinates of the evaluation points.
+      if (Plugins::plugin_type_matches<GeometryModel::Chunk<dim>>(this->get_geometry_model()) ||
+          Plugins::plugin_type_matches<GeometryModel::SphericalShell<dim>>(this->get_geometry_model()) ||
+          Plugins::plugin_type_matches<GeometryModel::Sphere<dim>>(this->get_geometry_model()))
+        is_spherical = true;
+      else
+        is_spherical = false;
 
       unsigned int rank = Utilities::MPI::this_mpi_process(this->get_mpi_communicator());
       if (rank >= n_landlab_ranks)
@@ -186,17 +196,27 @@ namespace aspect
             Py_DECREF(pDict);
             PyObject *pgrid_x = call_python_function(pModule, "get_grid_x", pArgs);
             PyObject *pgrid_y = nullptr;
+            PyObject *pgrid_z = nullptr;
             if (dim == 3)
-                pgrid_y = call_python_function(pModule, "get_grid_y", pArgs);
+              pgrid_y = call_python_function(pModule, "get_grid_y", pArgs);
+            if (dim == 3 && is_spherical)
+              pgrid_z = call_python_function(pModule, "get_grid_z", pArgs);
             Py_DECREF(pArgs);
 
             const ArrayView<double> data_x = PythonHelper::numpy_to_array_view(pgrid_x);
             const ArrayView<double> data_y = (dim == 3)
                                              ? PythonHelper::numpy_to_array_view(pgrid_y)
                                              : ArrayView<double>(nullptr, 0);
+            // For 3D spherical models, we need the z coordinates of the LandLab grid to be able to
+            // correctly set the evaluation points.
+            const ArrayView<double> data_z = (dim == 3 && is_spherical)
+                                             ? PythonHelper::numpy_to_array_view(pgrid_z)
+                                             : ArrayView<double>(nullptr, 0);
 
             if (dim == 3)
               AssertThrow(data_x.size() == data_y.size(), ExcMessage("get_grid_x and get_grid_y returned different sizes"));
+            if (dim == 3 && is_spherical)
+              AssertThrow(data_x.size() == data_z.size(), ExcMessage("get_grid_x and get_grid_z returned different sizes"));
 
             std::vector<Point<dim>> surface_points(data_x.size());
             for (size_t i = 0; i < data_x.size(); i++)
@@ -206,6 +226,9 @@ namespace aspect
                 if (dim == 3)
                   point(1) = data_y[i];
                 point(dim-1) = this->get_geometry_model().representative_point(0.0)[dim-1];
+
+                if (dim == 3 && is_spherical)
+                  point(dim-1) = data_z[i];
                 surface_points[i] = point;
               }
 
@@ -321,22 +344,31 @@ namespace aspect
       std::vector<Tensor<1,dim>> initial_deformation(this->evaluation_points.size(), Tensor<1,dim>());
       if (pModule)
         {
-          Tensor<1,dim> topography_direction;
-          topography_direction[dim-1] = 1.0;
-
           PyObject *pDict = PyDict_New();
           PyDict_SetItemString(pDict, "MPI Process", PyLong_FromLong(1.0));
           PyDict_SetItemString(pDict, "ASPECT Dimension", PyLong_FromLong(dim));
 
           PyObject *pArgs = PyTuple_Pack(1,
-                                          pDict
+                                         pDict
                                         );
           Py_DECREF(pDict);
           PyObject *pValue = call_python_function(pModule, "get_initial_topography", pArgs);
           Py_DECREF(pArgs);
           ArrayView<double> data = PythonHelper::numpy_to_array_view(pValue);
+
           for (size_t i=0; i<data.size(); ++i)
-            initial_deformation[i] = data[i] * topography_direction;
+            {
+              const Tensor<1,dim> gravity = this->get_gravity_model().gravity_vector(this->evaluation_points[i]);
+
+              Tensor<1,dim> topography_direction;
+              if (gravity.norm() > 0.0)
+                topography_direction = -gravity / gravity.norm();
+
+              if (data[i] > 0.0)
+                std::cout << this->evaluation_points[i] << std::endl;
+
+              initial_deformation[i] = data[i] * topography_direction;
+            }
           Py_DECREF(pValue);
         }
 

--- a/source/mesh_deformation/landlab.cc
+++ b/source/mesh_deformation/landlab.cc
@@ -154,7 +154,7 @@ namespace aspect
 
           {
             // Initialize landlab components
-            // If Use years instead of seconds is false, then we want to make sure we scale the 
+            // If Use years instead of seconds is false, then we want to make sure we scale the
             // parameters in landlab to seconds, since surface processes parameters are reported
             // typically in years.
             double time_scaling_factor = 1.0;
@@ -170,11 +170,11 @@ namespace aspect
                                           );
             Py_DECREF(pDict);
 
-            PyObject *pValue = call_python_function(pModule, "initalize_landlab_components", pArgs);
+            PyObject *pValue = call_python_function(pModule, "initialize_landlab_components", pArgs);
             Py_DECREF(pArgs);
             Py_DECREF(pValue);
           }
-          
+
           {
             // get grid points from the landlab mesh:
             PyObject *pArgs = PyTuple_Pack(1, PyLong_FromLong(-1L));
@@ -228,9 +228,6 @@ namespace aspect
       Assert(current_solution_at_points.size() == this->evaluation_points.size(), ExcInternalError());
       std::vector<Tensor<1,dim>> velocities(current_solution_at_points.size(), Tensor<1,dim>());
 
-      // What seems to be happening here is that we check if the python script has been loaded/exists. If it does,
-      // we enter this block. In this block, a python dictionary is made which contains the variables that are 
-      // to be passed over to LandLab. 
       if (pModule)
         {
           // Build a dictionary with solution values for each variable to pass to Python:
@@ -246,7 +243,6 @@ namespace aspect
               for (unsigned int j=0; j<current_solution_at_points.size(); ++j)
                 {
                   variable_data[i][j] = current_solution_at_points[j][i];
-                  // std::cout << this->evaluation_points[j] << ": " << variable_names[i] << " = " << variable_data[i][j] << std::endl;
                 }
             }
           for (unsigned int i=0; i<variable_names.size(); ++i)
@@ -255,10 +251,10 @@ namespace aspect
               PyDict_SetItemString(pDict, variable_names[i].c_str(), pValue.get());
             }
 
-          // Call update_until(). update_until() returns deposition_erosion. This is what eventually 
+          // Call update_until(). update_until() returns deposition_erosion. This is what eventually
           // gets converted to velocities to deform the ASPECT mesh.
           PyObject *pArgs = PyTuple_Pack(2, PyFloat_FromDouble(this->get_time()), pDict);
-          PyObject *pValue = call_python_function(pModule, "update_until", pArgs); // This line calls the landlab function
+          PyObject *pValue = call_python_function(pModule, "update_until", pArgs);
           Py_DECREF(pDict);
           Py_DECREF(pArgs);
 
@@ -408,17 +404,17 @@ namespace aspect
                             "Units: \\si{\\meter\\raisedto{-1}\\per\\year}.");
 
           prm.enter_subsection("Mesh information");
-           {
-              prm.declare_entry("X extent", "100e3",
-                                Patterns::Double(0),
-                                "The extent of the Landlab grid in the x direction. Units: \\si{\\meter}.");
-              prm.declare_entry("Y extent", "100e3",
-                                Patterns::Double(0),
-                                "The extent of the Landlab grid in the y direction. Units: \\si{\\meter}.");
-              prm.declare_entry("Spacing", "1000",
-                                Patterns::Double(0),
-                                "The spacing of the Landlab grid. Units: \\si{\\meter}.");
-           }
+          {
+            prm.declare_entry("X extent", "100e3",
+                              Patterns::Double(0),
+                              "The extent of the Landlab grid in the x direction. Units: \\si{\\meter}.");
+            prm.declare_entry("Y extent", "100e3",
+                              Patterns::Double(0),
+                              "The extent of the Landlab grid in the y direction. Units: \\si{\\meter}.");
+            prm.declare_entry("Spacing", "1000",
+                              Patterns::Double(0),
+                              "The spacing of the Landlab grid. Units: \\si{\\meter}.");
+          }
           prm.leave_subsection();
         }
         prm.leave_subsection();
@@ -450,13 +446,12 @@ namespace aspect
           else
             AssertThrow(false, ExcMessage("The parameter 'Define LandLab parameters using years' must be set to 'true' or 'false'"));
 
-            prm.enter_subsection("Mesh information");
-              {
-                // These parameters are not actually used in the C++ code, but we parse them here so that they are available in the Python script via the set_mesh_information() function.
-                landlab_x_extent = prm.get_double("X extent");
-                landlab_y_extent = prm.get_double("Y extent");
-                landlab_spacing = prm.get_double("Spacing");
-              }
+          prm.enter_subsection("Mesh information");
+          {
+            landlab_x_extent = prm.get_double("X extent");
+            landlab_y_extent = prm.get_double("Y extent");
+            landlab_spacing = prm.get_double("Spacing");
+          }
           prm.leave_subsection();
         }
         prm.leave_subsection ();

--- a/source/mesh_deformation/landlab.cc
+++ b/source/mesh_deformation/landlab.cc
@@ -264,7 +264,7 @@ namespace aspect
 
           const ArrayView<const double> data = PythonHelper::numpy_to_array_view(pValue);
           for (size_t i=0; i<data.size(); ++i)
-            velocities[i][dim-1] = data[i];
+            velocities[i][dim-1] = data[i] / (this->get_timestep() > 0.0 ? this->get_timestep() : 1.0);
 
           Py_DECREF(pValue);
         }

--- a/source/mesh_deformation/landlab.cc
+++ b/source/mesh_deformation/landlab.cc
@@ -228,9 +228,6 @@ namespace aspect
       Assert(current_solution_at_points.size() == this->evaluation_points.size(), ExcInternalError());
       std::vector<Tensor<1,dim>> velocities(current_solution_at_points.size(), Tensor<1,dim>());
 
-      // What seems to be happening here is that we check if the python script has been loaded/exists. If it does,
-      // we enter this block. In this block, a python dictionary is made which contains the variables that are 
-      // to be passed over to LandLab. 
       if (pModule)
         {
           // Build a dictionary with solution values for each variable to pass to Python:
@@ -246,7 +243,6 @@ namespace aspect
               for (unsigned int j=0; j<current_solution_at_points.size(); ++j)
                 {
                   variable_data[i][j] = current_solution_at_points[j][i];
-                  // std::cout << this->evaluation_points[j] << ": " << variable_names[i] << " = " << variable_data[i][j] << std::endl;
                 }
             }
           for (unsigned int i=0; i<variable_names.size(); ++i)
@@ -258,7 +254,7 @@ namespace aspect
           // Call update_until(). update_until() returns deposition_erosion. This is what eventually
           // gets converted to velocities to deform the ASPECT mesh.
           PyObject *pArgs = PyTuple_Pack(2, PyFloat_FromDouble(this->get_time()), pDict);
-          PyObject *pValue = call_python_function(pModule, "update_until", pArgs); // This line calls the landlab function
+          PyObject *pValue = call_python_function(pModule, "update_until", pArgs);
           Py_DECREF(pDict);
           Py_DECREF(pArgs);
 

--- a/source/mesh_deformation/landlab.cc
+++ b/source/mesh_deformation/landlab.cc
@@ -126,7 +126,6 @@ namespace aspect
     void
     Landlab<dim>::update ()
     {
-
 #ifdef ASPECT_WITH_PYTHON
       if (!this->remote_point_evaluator)
         {
@@ -176,23 +175,26 @@ namespace aspect
           }
 
           {
-            // get grid points from the landlab mesh:
-            PyObject *pArgs = PyTuple_Pack(1, PyLong_FromLong(-1L));
-            PyObject *pgrid_x = call_python_function(pModule, "get_grid_x", pArgs);
-            Py_DECREF(pArgs);
+            // get grid:
+            PyObject *pDict = PyDict_New();
+            PyDict_SetItemString(pDict, "MPI Process", PyLong_FromLong(1.0));
+            PyDict_SetItemString(pDict, "ASPECT Dimension", PyLong_FromLong(dim));
 
+            PyObject *pArgs = PyTuple_Pack(1,
+                                           pDict
+                                          );
+            Py_DECREF(pDict);
+            PyObject *pgrid_x = call_python_function(pModule, "get_grid_x", pArgs);
             PyObject *pgrid_y = nullptr;
             if (dim == 3)
-              {
-                PyObject *pArgs = PyTuple_Pack(1, PyLong_FromLong(-1L));
                 pgrid_y = call_python_function(pModule, "get_grid_y", pArgs);
-                Py_DECREF(pArgs);
-              }
+            Py_DECREF(pArgs);
 
             const ArrayView<double> data_x = PythonHelper::numpy_to_array_view(pgrid_x);
             const ArrayView<double> data_y = (dim == 3)
                                              ? PythonHelper::numpy_to_array_view(pgrid_y)
                                              : ArrayView<double>(nullptr, 0);
+
             if (dim == 3)
               AssertThrow(data_x.size() == data_y.size(), ExcMessage("get_grid_x and get_grid_y returned different sizes"));
 
@@ -209,7 +211,7 @@ namespace aspect
 
             // Clean up Python objects
             Py_DECREF(pgrid_x);
-            if (pgrid_y)
+            if (dim == 3)
               Py_DECREF(pgrid_y);
 
             this->set_evaluation_points(surface_points);
@@ -225,6 +227,7 @@ namespace aspect
     Landlab<dim>::compute_updated_velocities_at_points (const std::vector<std::vector<double>> &current_solution_at_points) const
     {
 #ifdef ASPECT_WITH_PYTHON
+
       Assert(current_solution_at_points.size() == this->evaluation_points.size(), ExcInternalError());
       std::vector<Tensor<1,dim>> velocities(current_solution_at_points.size(), Tensor<1,dim>());
 
@@ -237,7 +240,6 @@ namespace aspect
           // Create a vector<vector> that is of the shape (n_variables, n_points)
           std::vector<std::vector<double>> variable_data(variable_names.size(),  std::vector<double>(current_solution_at_points.size(), 0.0));
 
-          // Fill variable_data (which corresponds to the LandLab nodal points) with the values from ASPECT.
           for (unsigned int i=0; i<variable_names.size(); ++i)
             {
               for (unsigned int j=0; j<current_solution_at_points.size(); ++j)
@@ -251,8 +253,8 @@ namespace aspect
               PyDict_SetItemString(pDict, variable_names[i].c_str(), pValue.get());
             }
 
-          // Call update_until(). update_until() returns deposition_erosion. This is what eventually
-          // gets converted to velocities to deform the ASPECT mesh.
+          // Call update_until(). update_until() returns the change in the LandLab topography,
+          // which eventually gets converted to a velocity that deforms the ASPECT surface.
           PyObject *pArgs = PyTuple_Pack(2, PyFloat_FromDouble(this->get_time()), pDict);
           PyObject *pValue = call_python_function(pModule, "update_until", pArgs);
           Py_DECREF(pDict);
@@ -260,7 +262,9 @@ namespace aspect
 
           const ArrayView<const double> data = PythonHelper::numpy_to_array_view(pValue);
           for (size_t i=0; i<data.size(); ++i)
-            velocities[i][dim-1] = data[i] / (this->get_timestep() > 0.0 ? this->get_timestep() : 1.0);
+            {
+              velocities[i][dim-1] = data[i] / (this->get_timestep() > 0.0 ? this->get_timestep() : 1.0);
+            }
 
           Py_DECREF(pValue);
         }
@@ -320,7 +324,14 @@ namespace aspect
           Tensor<1,dim> topography_direction;
           topography_direction[dim-1] = 1.0;
 
-          PyObject *pArgs = PyTuple_Pack(1, PyLong_FromLong(-1L));
+          PyObject *pDict = PyDict_New();
+          PyDict_SetItemString(pDict, "MPI Process", PyLong_FromLong(1.0));
+          PyDict_SetItemString(pDict, "ASPECT Dimension", PyLong_FromLong(dim));
+
+          PyObject *pArgs = PyTuple_Pack(1,
+                                          pDict
+                                        );
+          Py_DECREF(pDict);
           PyObject *pValue = call_python_function(pModule, "get_initial_topography", pArgs);
           Py_DECREF(pArgs);
           ArrayView<double> data = PythonHelper::numpy_to_array_view(pValue);
@@ -330,6 +341,7 @@ namespace aspect
         }
 
       // 2. Interpolate deformation into a DoF vector:
+
       LinearAlgebra::Vector initial_deformation_dof_vector = this->interpolate_external_velocities_to_surface_support_points(initial_deformation);
       const DoFHandler<dim> &mesh_dof_handler = this->get_mesh_deformation_handler().get_mesh_deformation_dof_handler();
       const IndexSet mesh_locally_relevant = DoFTools::extract_locally_relevant_dofs (mesh_dof_handler);

--- a/source/mesh_deformation/landlab.cc
+++ b/source/mesh_deformation/landlab.cc
@@ -141,14 +141,42 @@ namespace aspect
 
           {
             // set_mesh_information: call with None
-            PyObject *pArgs = PyTuple_Pack(1, Py_None);
+            PyObject *pDict = PyDict_New();
+            PyDict_SetItemString(pDict, "Mesh X extent", PyFloat_FromDouble(landlab_x_extent));
+            PyDict_SetItemString(pDict, "Mesh Y extent", PyFloat_FromDouble(landlab_y_extent));
+            PyDict_SetItemString(pDict, "Mesh Spacing", PyFloat_FromDouble(landlab_spacing));
+
+            PyObject *pArgs = PyTuple_Pack(1, pDict);
             PyObject *pValue = call_python_function(pModule, "set_mesh_information", pArgs);
             Py_DECREF(pArgs);
             Py_DECREF(pValue);
           }
 
           {
-            // get grid:
+            // Initialize landlab components
+            // If Use years instead of seconds is false, then we want to make sure we scale the 
+            // parameters in landlab to seconds, since surface processes parameters are reported
+            // typically in years.
+            double time_scaling_factor = 1.0;
+            if (parameters_in_years)
+              time_scaling_factor = year_in_seconds;
+
+            PyObject *pDict = PyDict_New();
+            PyDict_SetItemString(pDict, "Hillslope coefficient", PyFloat_FromDouble(hillslope_diffusion_coefficient / time_scaling_factor));
+            PyDict_SetItemString(pDict, "Stream power erodibility coefficient", PyFloat_FromDouble(stream_power_erodibility_coefficient / time_scaling_factor));
+
+            PyObject *pArgs = PyTuple_Pack(1,
+                                           pDict
+                                          );
+            Py_DECREF(pDict);
+
+            PyObject *pValue = call_python_function(pModule, "initalize_landlab_components", pArgs);
+            Py_DECREF(pArgs);
+            Py_DECREF(pValue);
+          }
+          
+          {
+            // get grid points from the landlab mesh:
             PyObject *pArgs = PyTuple_Pack(1, PyLong_FromLong(-1L));
             PyObject *pgrid_x = call_python_function(pModule, "get_grid_x", pArgs);
             Py_DECREF(pArgs);
@@ -200,17 +228,25 @@ namespace aspect
       Assert(current_solution_at_points.size() == this->evaluation_points.size(), ExcInternalError());
       std::vector<Tensor<1,dim>> velocities(current_solution_at_points.size(), Tensor<1,dim>());
 
+      // What seems to be happening here is that we check if the python script has been loaded/exists. If it does,
+      // we enter this block. In this block, a python dictionary is made which contains the variables that are 
+      // to be passed over to LandLab. 
       if (pModule)
         {
           // Build a dictionary with solution values for each variable to pass to Python:
           PyObject *pDict = PyDict_New();
+          // variable names must match those expected by the Landlab script:
           const std::vector<std::string> variable_names = { "x velocity", "y velocity", "z velocity" };
+          // Create a vector<vector> that is of the shape (n_variables, n_points)
           std::vector<std::vector<double>> variable_data(variable_names.size(),  std::vector<double>(current_solution_at_points.size(), 0.0));
+
+          // Fill variable_data (which corresponds to the LandLab nodal points) with the values from ASPECT.
           for (unsigned int i=0; i<variable_names.size(); ++i)
             {
               for (unsigned int j=0; j<current_solution_at_points.size(); ++j)
                 {
                   variable_data[i][j] = current_solution_at_points[j][i];
+                  // std::cout << this->evaluation_points[j] << ": " << variable_names[i] << " = " << variable_data[i][j] << std::endl;
                 }
             }
           for (unsigned int i=0; i<variable_names.size(); ++i)
@@ -219,9 +255,10 @@ namespace aspect
               PyDict_SetItemString(pDict, variable_names[i].c_str(), pValue.get());
             }
 
-          // Call update_until()
+          // Call update_until(). update_until() returns deposition_erosion. This is what eventually 
+          // gets converted to velocities to deform the ASPECT mesh.
           PyObject *pArgs = PyTuple_Pack(2, PyFloat_FromDouble(this->get_time()), pDict);
-          PyObject *pValue = call_python_function(pModule, "update_until", pArgs);
+          PyObject *pValue = call_python_function(pModule, "update_until", pArgs); // This line calls the landlab function
           Py_DECREF(pDict);
           Py_DECREF(pArgs);
 
@@ -245,7 +282,7 @@ namespace aspect
           {
             real_evaluation_points[i] = this->evaluation_points[i];  // TODO: use mapping to compute real position
             for (unsigned int c=0; c<dim; ++c)
-              data[i][c] = velocities[i][c];
+              data[i][c] = velocities[i][c] / (this->get_timestep() > 0.0 ? this->get_timestep() : 1.0);
           }
 
         const std::vector<std::string> data_component_names(dim, "velocity");
@@ -356,6 +393,33 @@ namespace aspect
                             Patterns::Anything(),
                             "An arbitrary string to be passed to the initialize() function in the "
                             "Python script. Can be used to specify a configuration file or other option.");
+
+          prm.declare_entry("Define LandLab parameters using years", "unspecified",
+                            Patterns::Selection("true|false|unspecified"),
+                            "If true, the LandLab parameters (diffusion coefficient, erodibility, uplift rate) "
+                            "are defined in units per year. If false, they are defined in SI units (per second).");
+          prm.declare_entry("Hillslope diffusion coefficient", "0.01",
+                            Patterns::Double(0),
+                            "Hillslope diffusion coefficient used to compute the mesh deformation. "
+                            "Units: \\si{\\meter\\squared\\per\\year}.");
+          prm.declare_entry("Stream power erodibility coefficient", "1e-4",
+                            Patterns::Double(0),
+                            "Stream power erodibility coefficient used to compute the mesh deformation. "
+                            "Units: \\si{\\meter\\raisedto{-1}\\per\\year}.");
+
+          prm.enter_subsection("Mesh information");
+           {
+              prm.declare_entry("X extent", "100e3",
+                                Patterns::Double(0),
+                                "The extent of the Landlab grid in the x direction. Units: \\si{\\meter}.");
+              prm.declare_entry("Y extent", "100e3",
+                                Patterns::Double(0),
+                                "The extent of the Landlab grid in the y direction. Units: \\si{\\meter}.");
+              prm.declare_entry("Spacing", "1000",
+                                Patterns::Double(0),
+                                "The spacing of the Landlab grid. Units: \\si{\\meter}.");
+           }
+          prm.leave_subsection();
         }
         prm.leave_subsection();
       }
@@ -371,10 +435,29 @@ namespace aspect
       {
         prm.enter_subsection ("Landlab");
         {
-          n_landlab_ranks = prm.get_integer("MPI ranks for Landlab");
-          script_path = prm.get("Script path");
+          n_landlab_ranks    = prm.get_integer("MPI ranks for Landlab");
+          script_path        = prm.get("Script path");
           script_module_name = prm.get("Script name");
-          script_argument = prm.get("Script argument");
+          script_argument    = prm.get("Script argument");
+
+          hillslope_diffusion_coefficient      = prm.get_double("Hillslope diffusion coefficient");
+          stream_power_erodibility_coefficient = prm.get_double("Stream power erodibility coefficient");
+
+          if (prm.get ("Define LandLab parameters using years") == "true")
+            parameters_in_years = true;
+          else if (prm.get ("Define LandLab parameters using years") == "false")
+            parameters_in_years = false;
+          else
+            AssertThrow(false, ExcMessage("The parameter 'Define LandLab parameters using years' must be set to 'true' or 'false'"));
+
+            prm.enter_subsection("Mesh information");
+              {
+                // These parameters are not actually used in the C++ code, but we parse them here so that they are available in the Python script via the set_mesh_information() function.
+                landlab_x_extent = prm.get_double("X extent");
+                landlab_y_extent = prm.get_double("Y extent");
+                landlab_spacing = prm.get_double("Spacing");
+              }
+          prm.leave_subsection();
         }
         prm.leave_subsection ();
       }


### PR DESCRIPTION
First pass at supporting spherical geometries. There are no examples here yet because (I think) the conversion between spherical/cartesian is being handled differently in LandLab/ASPECT. Models will run with the changes in this PR, but currently the topography that is passed from LandLab to ASPECT is wrong. The test I'm working on prescribes half of the Earth to have a topography of 1000 m, and the other half to have 0 m. The initial topography that is output by ASPECT looks like this though:

<img width="651" height="450" alt="image" src="https://github.com/user-attachments/assets/58b73b0a-c8af-479e-8b2f-75d82cfd15a5" />

I'll update this PR with the example once I figure out this discrepancy, but I wanted to open this anyway so that I can get feedback on the code changes.

@tjhei @bangerth 