### PR TITLE
Send Composition to LandLab

### DIFF
--- a/cookbooks/landlab/composition-coupling/2D-variable_diffusivity.prm
+++ b/cookbooks/landlab/composition-coupling/2D-variable_diffusivity.prm
@@ -1,0 +1,181 @@
+# This cookbook is used as a test to ensure that FastScape is properly working with ASPECT.
+# It consists of a 2.5 km high central mountain block that is eroded through the use of
+# hillslope diffusion and the Stream Power Law. Within ASPECT, the model is based off
+# convection-box-3d. However, it is set up in a way that nothing happens in the geodynamic model.
+
+# At the top, we define the number of space dimensions we would like to
+# work in:
+set Dimension                              = 2
+set Use years instead of seconds           = true
+set End time                               = 10e6
+set Maximum time step                      = 10000
+set Output directory                       = test-variable-diffusivity
+set Pressure normalization                 = no
+set Surface pressure                       = 0
+set Resume computation                     = false
+set Nonlinear solver scheme                = iterated Advection and Stokes
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block AMG
+  end
+end
+
+subsection Discretization
+  set Composition polynomial degree           = 2
+  set Stokes velocity polynomial degree       = 2
+  set Temperature polynomial degree           = 2
+  set Use discontinuous composition discretization = true
+end
+
+# A box that has an initial 60x60 km mountain block that is 2.5 km above the initial model surface.
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 100e3
+    set Y extent = 25e3
+
+    set X repetitions = 4
+    set Y repetitions = 1
+  end
+end
+
+# We do not consider temperature in this setup
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = bottom, top
+  set List of model names = initial temperature
+end
+
+# X Set all boundaries except the top to freeslip.
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = bottom:function, left:function, right:function #, front:function, back:function
+  subsection Function
+    set Coordinate system   = cartesian
+    set Variable names      = x,y,t
+    set Function constants  = uplift_rate=0, cm=0.0
+    set Function expression = 0; uplift_rate * cm
+  end
+end
+
+# subsection Boundary traction model
+#   set Prescribed traction boundary indicators = right: initial lithostatic pressure, left: initial lithostatic pressure
+#   subsection Initial lithostatic pressure
+#     set Number of integration points = 10000
+#     set Representative point         = 0.0, 0.0
+#   end
+# end
+
+# Here we setup the top boundary with fastscape.
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: Landlab
+  set Additional tangential mesh velocity boundary indicators = left, right
+
+  subsection Landlab
+    set MPI ranks for Landlab = 1
+    # set Script name           = 2D-rectangular_topography
+    set Script name           = variable-diffusivity
+    set Script argument       =
+    set Script path           =
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 1e-100
+  end
+end
+
+# Dimensionless
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 1
+    set Thermal expansion coefficient = 1
+    set Viscosity                     = 1
+  end
+end
+
+# We also have to specify that we want to use the Boussinesq
+# approximation (assuming the density in the temperature
+# equation to be constant, and incompressibility).
+subsection Formulation
+  set Formulation = Boussinesq approximation
+end
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Compositional field methods =  field, field
+  set Types of fields =  chemical composition,  chemical composition
+  set Names of fields = strong, weak
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Coordinate system   =  cartesian
+    set Variable names      =  x,y,t
+    set Function expression = if(x>=50e3, 0.0, 1.0); if(x<=50e3, 0.0, 1.0)
+  end
+end
+
+subsection Boundary composition model
+  set Fixed composition boundary indicators         = bottom, top
+  set List of model names                           =  initial composition
+  set Allow fixed composition on outflow boundaries = true
+end
+
+
+# We set a maximum surface refinement level of 4 using the max/minimum refinement level.
+# This will make it so that the ASPECT surface refinement is the same as what we set
+# for our maximum surface refinement level for FastScape.
+subsection Mesh refinement
+  set Initial global refinement                = 3
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+#   set Strategy                                 = minimum refinement function, maximum refinement function
+
+#   subsection Maximum refinement function
+#     set Coordinate system   = cartesian
+#     set Variable names      = x,y,z
+#     set Function expression = if(y>=21000, 4, 2)
+#   end
+
+#   subsection Minimum refinement function
+#     set Coordinate system   = cartesian
+#     set Variable names      = x,y,z
+#     set Function expression = if(y>=21000, 4, 2)
+#   end
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, topography, velocity statistics, composition statistics
+
+  subsection Topography
+    set Output to file = true
+    set Time between text output = 50e3
+  end
+
+  subsection Visualization
+    set Time between graphical output = 50e3
+    set Output mesh velocity = true
+    set Output mesh displacement = true
+    set Output undeformed mesh = false
+    set Interpolate output = false
+  end
+
+end

--- a/cookbooks/landlab/composition-coupling/variable-diffusivity.py
+++ b/cookbooks/landlab/composition-coupling/variable-diffusivity.py
@@ -1,0 +1,208 @@
+
+from mpi4py import MPI
+import json
+import os
+import numpy as np
+import landlab
+from landlab.components import LinearDiffuser
+
+from landlab.io.legacy_vtk import write_legacy_vtk
+
+current_time = 0
+
+comm = None
+
+model_grid = None
+elevation = None
+linear_diffuser = None
+Diffusivity = None
+
+s2yr = 60 * 60 * 24 * 365.25
+timestep = 0
+vtks = []
+
+def initialize(comm_handle):
+    if not comm_handle is None:
+        # Convert the handle back to an MPI communicator
+        global comm
+        comm = MPI.Comm.f2py(comm_handle)
+
+        rank = comm.Get_rank()
+        size = comm.Get_size()
+
+        print(f"Python: Hello from Rank {rank} of {size}")
+
+        data = 1
+        globalsum = comm.allreduce(data, op=MPI.SUM)
+        if comm.rank == 0:
+            print(f"\tPython: testing communication; sum {globalsum}")
+    else:
+        print("Python: running sequentially!")
+
+def finalize():
+    pass
+
+
+# Run the Landlab simulation from the current time to end_time and return
+# the new topographic elevation (in m) at each local node.
+# dict_variable_name_to_value_in_nodes is a dictionary mapping variables
+# (x velocity, y velocity, temperature, etc.) to an array of values in each
+# node.
+def update_until(end_time, dict_variable_name_to_value_in_nodes):
+    global current_time, elevation, linear_diffuser, timestep, Diffusivity
+
+    dt = end_time - current_time
+    timestep += 1
+
+    deposition_erosion = np.zeros(model_grid.number_of_nodes)
+
+    # Extract the velocity along the ASPECT model, which is located at y=0 on the landlab mesh.
+    slice_x_velocity = dict_variable_name_to_value_in_nodes["x velocity"]
+    slice_y_velocity = dict_variable_name_to_value_in_nodes["y velocity"]
+    # slice_z_velocity = dict_variable_name_to_value_in_nodes["z velocity"]
+
+    # Likewise, extract the composition along the ASPECT surface. These exactly match the names
+    # of the compositions provided to ASPECT.
+    slice_weak_composition   = dict_variable_name_to_value_in_nodes["weak"]
+    slice_strong_composition = dict_variable_name_to_value_in_nodes["strong"]
+
+    # Create empty arrays to project the velocity and composition values out from y=0 to all
+    # nodes on the landlab mesh.
+    vertical_velocity = np.zeros(model_grid.number_of_nodes)
+    strong_composition = np.zeros(model_grid.number_of_nodes)
+    weak_composition   = np.zeros(model_grid.number_of_nodes)
+
+    unique_x_values   = np.unique(model_grid.x_of_node)
+    for x in unique_x_values:
+        vertical_velocity[model_grid.x_of_node == x]  = slice_y_velocity[unique_x_values == x]
+        strong_composition[model_grid.x_of_node == x] = slice_strong_composition[unique_x_values == x]
+        weak_composition[model_grid.x_of_node == x]   = slice_weak_composition[unique_x_values == x]
+
+    # Modify the diffusivity based on the composition, making it very high for "weak" and low for "strong".
+    Diffusivity[strong_composition >= 0.5] = 1e-10 / s2yr
+    Diffusivity[weak_composition >= 0.5]   = 10 / s2yr
+
+    # Substepping for surface processes
+    if dt>0:
+        n_substeps = 10
+        sub_dt = dt / n_substeps
+        for _ in range(n_substeps):
+
+          elevation_before = elevation.copy()
+
+          linear_diffuser.run_one_step(sub_dt)
+
+          elevation += vertical_velocity * sub_dt
+
+          deposition_erosion += elevation - elevation_before
+        pass
+
+    current_time = end_time
+    print("Max elevation:", np.max(elevation), "Min elevation:", np.min(elevation))
+
+    # Return the change in the topography along y=0, where the ASPECT mesh is located.
+    deposition_erosion_2d = np.zeros(len(np.unique(model_grid.x_of_node)))
+    for x in unique_x_values:
+        deposition_erosion_2d = deposition_erosion[model_grid.y_of_node == 0]
+    
+    return deposition_erosion_2d
+
+def set_mesh_information(dict_grid_information):
+    global model_grid, elevation
+
+    if not model_grid:
+        print("* Creating RasterModelGrid ...")
+        x_extent = 100e3
+        y_extent = 100e3
+        spacing  = 500.0
+
+        nrows = int(y_extent / spacing) + 1 # number of node rows
+        ncols = int(x_extent / spacing) + 1 # number of node columns
+
+        model_grid = landlab.RasterModelGrid((nrows, ncols), xy_spacing=(spacing, spacing), xy_of_lower_left=(0, -y_extent / 2))
+
+        print("* Creating topographic elevation ...")
+        # Initialize topography array with zeros
+        elevation = model_grid.add_zeros("topographic__elevation", at="node")
+
+        # Add a large 20 km high triangular mountain in the middle of the LandLab domain.
+        topo_height = 20e3
+        left_x_arr = np.array([25e3, 50e3])
+        left_y_arr = np.array([0.0, topo_height])
+
+        right_x_arr = np.array([50e3, 75e3])
+        right_y_arr = np.array([topo_height, 0.0])
+
+        left_m, left_b = np.polyfit(left_x_arr, left_y_arr, deg=1)
+        right_m, right_b = np.polyfit(right_x_arr, right_y_arr, deg=1)
+
+        elevation[model_grid.x_of_node <= 50e3] = left_m * model_grid.x_of_node[model_grid.x_of_node <= 50e3] + left_b
+        elevation[model_grid.x_of_node > 50e3]  = right_m * model_grid.x_of_node[model_grid.x_of_node > 50e3] + right_b
+
+        elevation[model_grid.x_of_node < np.min(left_x_arr)] = 0.0
+        elevation[model_grid.x_of_node > np.max(right_x_arr)] = 0.0
+
+        # Close all boundaries
+        model_grid.set_closed_boundaries_at_grid_edges(right_is_closed=True, 
+                                                       left_is_closed=True, 
+                                                       top_is_closed=True, 
+                                                       bottom_is_closed=True)
+                                                       
+        print("\tnumber of nodes:", model_grid.number_of_nodes)
+        initialize_landlab_components(None)
+
+        print("* Done")
+
+# If the ASPECT mesh is 2D, then we only want to return the unique values of x on the LandLab mesh,
+# the logic here is probably different if the LandLab mesh is not a raster.
+def get_grid_x(grid_dictionary):
+    global model_grid
+    return np.unique(model_grid.x_of_node)
+
+# If the ASPECT mesh is 2D, then we only return an array of 0s for the y values, since this is where
+# the ASPECT surface is located.
+def get_grid_y(grid_dictionary):
+    global model_grid
+    return np.zeros(np.unique(model_grid.x_of_node).shape)
+
+def initialize_landlab_components(landlab_component_parameters):
+    global model_grid, elevation, linear_diffuser, flow_accumulator, stream_power_eroder, Diffusivity
+
+    D = 1e-10 / s2yr
+    
+    # If the diffusivity is mapped to an array with the same length as the number of nodes on the landlab
+    # mesh, landlab will use those values as the diffusivity at each node. If these values are updated,
+    # landlab will also track this.
+    Diffusivity = model_grid.add_zeros("linear_diffusivity", at="node")
+    Diffusivity += D
+
+    # print("* Creating LinearDiffuser ... with D =", D)
+    linear_diffuser = LinearDiffuser(model_grid, linear_diffusivity=Diffusivity)
+    pass
+
+# Return the initial topography along y=0, where the ASPECT surface is located.
+def get_initial_topography(grid_dictionary):
+    global elevation
+    return elevation[model_grid.y_of_node == 0]
+
+
+def write_output(timestep):
+    # Write the grid to vtk
+    print("Writing output VTK file...")
+    vtk_file = write_legacy_vtk(path=f"./output_{str(timestep).zfill(3)}.vtk", grid=model_grid, clobber=True)
+
+if __name__ == "__main__":
+    comm = MPI.COMM_WORLD
+    initialize(MPI.Comm.py2f(comm))
+
+    set_mesh_information({})
+    initialize_landlab_components(None)
+
+     # Main simulation loop
+    for n in range(100):
+        data = {}
+        data["x velocity"] = np.zeros(model_grid.number_of_nodes)
+        data["y velocity"] = np.zeros(model_grid.number_of_nodes)
+        data["z velocity"] = np.zeros(model_grid.number_of_nodes)
+        update_until(n*dt, data)
+        write_output(n)

--- a/source/mesh_deformation/external_tool_interface.cc
+++ b/source/mesh_deformation/external_tool_interface.cc
@@ -282,7 +282,7 @@ namespace aspect
                          "and if the evaluator has not been invalidated by a mesh "
                          "refinement step."));
 
-      // All components are evaluted (velocity, pressure, temperature, and N compositional fields).
+      // All components are evaluated (velocity, pressure, temperature, and N compositional fields).
       const unsigned int n_components = this->introspection().n_components;
       std::vector<std::vector<double>> solution_at_points (evaluation_points.size(), std::vector<double>(n_components, 0.0));
 

--- a/source/mesh_deformation/external_tool_interface.cc
+++ b/source/mesh_deformation/external_tool_interface.cc
@@ -282,6 +282,7 @@ namespace aspect
                          "and if the evaluator has not been invalidated by a mesh "
                          "refinement step."));
 
+      // All components are evaluted (velocity, pressure, temperature, and N compositional fields).
       const unsigned int n_components = this->introspection().n_components;
       std::vector<std::vector<double>> solution_at_points (evaluation_points.size(), std::vector<double>(n_components, 0.0));
 

--- a/source/mesh_deformation/landlab.cc
+++ b/source/mesh_deformation/landlab.cc
@@ -230,7 +230,17 @@ namespace aspect
         {
           // Build a dictionary with solution values for each variable to pass to Python:
           PyObject *pDict = PyDict_New();
-          const std::vector<std::string> variable_names = { "x velocity", "y velocity", "z velocity" };
+          std::vector<std::string> variable_names = { "x velocity", "y velocity"};
+          if (dim == 3)
+            variable_names.push_back("z velocity");
+
+          variable_names.push_back("pressure");
+          variable_names.push_back("temperature");
+
+          // Add compositional fields to the variable names and variable data:
+          for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
+            variable_names.push_back(this->introspection().name_for_compositional_index(c));
+
           std::vector<std::vector<double>> variable_data(variable_names.size(),  std::vector<double>(current_solution_at_points.size(), 0.0));
           for (unsigned int i=0; i<variable_names.size(); ++i)
             {


### PR DESCRIPTION
This PR updates the `compute_updated_velocities_at_points()` function to include ASPECT's composition components. 

Right now, all of the components of ASPECT are being evaluated in the `evaluate_aspect_variables_at_points()` function in external_tool_interface.cc. At the moment there's no reason to be sending temperature/pressure, but this might end up being useful in the future so I didn't change this. Instead, I also added pressure/temperature to the list of variables sent to LandLab.

The example is a 2D, simple diffusion model with an initial 20 km high mountain in the center. The left half is "strong" and the right half is "weak". The composition at the surface is sent to LandLab and then within python the diffusivity is updated based on the composition (red is strong and blue is weak). The weak half of the model diffuses rapidly, the strong side does not diffuse at all. 

![static](https://github.com/user-attachments/assets/50f109c8-18a0-4584-b117-f5ee1ccc70b8)

This second test updates the composition on the boundary to be strong after 2 Myr. Before 2 Myr, the topography diffuses rapidly on the weak side, after 2 Myr when the boundary composition is "strong", the topography stops diffusing quickly. 

![time_update](https://github.com/user-attachments/assets/7dbee47a-6e75-4a39-9599-98241848bacd)
