### PR TITLE
Add checkpoint/restart functions to landlab.cc

### DIFF
--- a/cookbooks/landlab/2D-T-Models/T-model-LandLab.py
+++ b/cookbooks/landlab/2D-T-Models/T-model-LandLab.py
@@ -10,7 +10,6 @@ from landlab.components import StreamPowerEroder
 
 from landlab.io.legacy_vtk import write_legacy_vtk
 
-current_time = 0
 
 comm = None
 
@@ -51,8 +50,8 @@ def finalize():
 # dict_variable_name_to_value_in_nodes is a dictionary mapping variables
 # (x velocity, y velocity, temperature, etc.) to an array of values in each
 # node.
-def update_until(end_time, dict_variable_name_to_value_in_nodes):
-    global current_time, elevation, linear_diffuser, flow_accumulator, stream_power_eroder, timestep
+def update_until(end_time, current_time, dict_variable_name_to_value_in_nodes):
+    global elevation, linear_diffuser, flow_accumulator, stream_power_eroder, timestep
 
     dt = end_time - current_time
     timestep += 1

--- a/cookbooks/landlab/checkpointing/post-checkpoint.prm
+++ b/cookbooks/landlab/checkpointing/post-checkpoint.prm
@@ -1,0 +1,187 @@
+# This cookbook is used as a test to ensure that FastScape is properly working with ASPECT.
+# It consists of a 2.5 km high central mountain block that is eroded through the use of
+# hillslope diffusion and the Stream Power Law. Within ASPECT, the model is based off
+# convection-box-3d. However, it is set up in a way that nothing happens in the geodynamic model.
+
+# At the top, we define the number of space dimensions we would like to
+# work in:
+set Dimension                              = 2
+set Use years instead of seconds           = true
+# set End time                               = 5e6
+set End time                               = 2e6
+set Maximum time step                      = 1e4
+set Output directory                       = checkpoint-test
+set Pressure normalization                 = no
+set Surface pressure                       = 0
+set Resume computation                     = true
+set Nonlinear solver scheme                = iterated Advection and Stokes
+
+subsection Checkpointing
+  # set Time between checkpoint = 1
+  set Steps between checkpoint = 33
+  set Resume checkpoint        = 1
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block AMG
+  end
+end
+
+subsection Discretization
+  set Composition polynomial degree           = 2
+  set Stokes velocity polynomial degree       = 2
+  set Temperature polynomial degree           = 2
+  set Use discontinuous composition discretization = true
+end
+
+# A box that has an initial 60x60 km mountain block that is 2.5 km above the initial model surface.
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 100e3
+    set Y extent = 25e3
+
+    set X repetitions = 4
+    set Y repetitions = 1
+  end
+end
+
+# We do not consider temperature in this setup
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = bottom, top
+  set List of model names = initial temperature
+end
+
+# X Set all boundaries except the top to freeslip.
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = bottom:function, left:function, right:function #, front:function, back:function
+  subsection Function
+    set Coordinate system   = cartesian
+    set Variable names      = x,y,t
+    set Function constants  = uplift_rate=0, cm=0.0
+    set Function expression = 0; uplift_rate * cm
+  end
+end
+
+# subsection Boundary traction model
+#   set Prescribed traction boundary indicators = right: initial lithostatic pressure, left: initial lithostatic pressure
+#   subsection Initial lithostatic pressure
+#     set Number of integration points = 10000
+#     set Representative point         = 0.0, 0.0
+#   end
+# end
+
+# Here we setup the top boundary with fastscape.
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: Landlab
+  set Additional tangential mesh velocity boundary indicators = left, right
+
+  subsection Landlab
+    set MPI ranks for Landlab = 1
+    set Script name           = simple_checkpoint
+    set Script argument       =
+    set Script path           =
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 1e-100
+  end
+end
+
+# Dimensionless
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 1
+    set Thermal expansion coefficient = 1
+    set Viscosity                     = 1
+  end
+end
+
+# We also have to specify that we want to use the Boussinesq
+# approximation (assuming the density in the temperature
+# equation to be constant, and incompressibility).
+subsection Formulation
+  set Formulation = Boussinesq approximation
+end
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Compositional field methods =  field, field
+  set Types of fields =  chemical composition,  chemical composition
+  set Names of fields = strong, weak
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Coordinate system   =  cartesian
+    set Variable names      =  x,y,t
+    set Function expression = if(x>=50e3, 0.0, 1.0); if(x<=50e3, 0.0, 1.0)
+  end
+end
+
+subsection Boundary composition model
+  set Fixed composition boundary indicators         = bottom, top
+  set List of model names                           =  initial composition
+  set Allow fixed composition on outflow boundaries = true
+end
+
+
+# We set a maximum surface refinement level of 4 using the max/minimum refinement level.
+# This will make it so that the ASPECT surface refinement is the same as what we set
+# for our maximum surface refinement level for FastScape.
+subsection Mesh refinement
+  set Initial global refinement                = 3
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+#   set Strategy                                 = minimum refinement function, maximum refinement function
+
+#   subsection Maximum refinement function
+#     set Coordinate system   = cartesian
+#     set Variable names      = x,y,z
+#     set Function expression = if(y>=21000, 4, 2)
+#   end
+
+#   subsection Minimum refinement function
+#     set Coordinate system   = cartesian
+#     set Variable names      = x,y,z
+#     set Function expression = if(y>=21000, 4, 2)
+#   end
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, topography, velocity statistics, composition statistics
+
+  subsection Topography
+    set Output to file = true
+    set Time between text output = 50e3
+  end
+
+  subsection Visualization
+    set Time between graphical output = 50e3
+    set Output mesh velocity = true
+    set Output mesh displacement = true
+    set Output undeformed mesh = false
+    set Interpolate output = false
+  end
+
+end

--- a/cookbooks/landlab/checkpointing/pre-checkpoint.prm
+++ b/cookbooks/landlab/checkpointing/pre-checkpoint.prm
@@ -1,0 +1,187 @@
+# This cookbook is used as a test to ensure that FastScape is properly working with ASPECT.
+# It consists of a 2.5 km high central mountain block that is eroded through the use of
+# hillslope diffusion and the Stream Power Law. Within ASPECT, the model is based off
+# convection-box-3d. However, it is set up in a way that nothing happens in the geodynamic model.
+
+# At the top, we define the number of space dimensions we would like to
+# work in:
+set Dimension                              = 2
+set Use years instead of seconds           = true
+# set End time                               = 5e6
+set End time                               = 1e6
+set Maximum time step                      = 1e4
+set Output directory                       = checkpoint-test
+set Pressure normalization                 = no
+set Surface pressure                       = 0
+set Resume computation                     = false
+set Nonlinear solver scheme                = iterated Advection and Stokes
+
+subsection Checkpointing
+  # set Time between checkpoint = 1
+  set Steps between checkpoint = 33
+  set Resume checkpoint        = 1
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block AMG
+  end
+end
+
+subsection Discretization
+  set Composition polynomial degree           = 2
+  set Stokes velocity polynomial degree       = 2
+  set Temperature polynomial degree           = 2
+  set Use discontinuous composition discretization = true
+end
+
+# A box that has an initial 60x60 km mountain block that is 2.5 km above the initial model surface.
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 100e3
+    set Y extent = 25e3
+
+    set X repetitions = 4
+    set Y repetitions = 1
+  end
+end
+
+# We do not consider temperature in this setup
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = bottom, top
+  set List of model names = initial temperature
+end
+
+# X Set all boundaries except the top to freeslip.
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = bottom:function, left:function, right:function #, front:function, back:function
+  subsection Function
+    set Coordinate system   = cartesian
+    set Variable names      = x,y,t
+    set Function constants  = uplift_rate=0, cm=0.0
+    set Function expression = 0; uplift_rate * cm
+  end
+end
+
+# subsection Boundary traction model
+#   set Prescribed traction boundary indicators = right: initial lithostatic pressure, left: initial lithostatic pressure
+#   subsection Initial lithostatic pressure
+#     set Number of integration points = 10000
+#     set Representative point         = 0.0, 0.0
+#   end
+# end
+
+# Here we setup the top boundary with fastscape.
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: Landlab
+  set Additional tangential mesh velocity boundary indicators = left, right
+
+  subsection Landlab
+    set MPI ranks for Landlab = 1
+    set Script name           = simple_checkpoint
+    set Script argument       =
+    set Script path           =
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 1e-100
+  end
+end
+
+# Dimensionless
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 1
+    set Thermal expansion coefficient = 1
+    set Viscosity                     = 1
+  end
+end
+
+# We also have to specify that we want to use the Boussinesq
+# approximation (assuming the density in the temperature
+# equation to be constant, and incompressibility).
+subsection Formulation
+  set Formulation = Boussinesq approximation
+end
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Compositional field methods =  field, field
+  set Types of fields =  chemical composition,  chemical composition
+  set Names of fields = strong, weak
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Coordinate system   =  cartesian
+    set Variable names      =  x,y,t
+    set Function expression = if(x>=50e3, 0.0, 1.0); if(x<=50e3, 0.0, 1.0)
+  end
+end
+
+subsection Boundary composition model
+  set Fixed composition boundary indicators         = bottom, top
+  set List of model names                           =  initial composition
+  set Allow fixed composition on outflow boundaries = true
+end
+
+
+# We set a maximum surface refinement level of 4 using the max/minimum refinement level.
+# This will make it so that the ASPECT surface refinement is the same as what we set
+# for our maximum surface refinement level for FastScape.
+subsection Mesh refinement
+  set Initial global refinement                = 3
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+#   set Strategy                                 = minimum refinement function, maximum refinement function
+
+#   subsection Maximum refinement function
+#     set Coordinate system   = cartesian
+#     set Variable names      = x,y,z
+#     set Function expression = if(y>=21000, 4, 2)
+#   end
+
+#   subsection Minimum refinement function
+#     set Coordinate system   = cartesian
+#     set Variable names      = x,y,z
+#     set Function expression = if(y>=21000, 4, 2)
+#   end
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, topography, velocity statistics, composition statistics
+
+  subsection Topography
+    set Output to file = true
+    set Time between text output = 50e3
+  end
+
+  subsection Visualization
+    set Time between graphical output = 50e3
+    set Output mesh velocity = true
+    set Output mesh displacement = true
+    set Output undeformed mesh = false
+    set Interpolate output = false
+  end
+
+end

--- a/cookbooks/landlab/checkpointing/simple_checkpoint.py
+++ b/cookbooks/landlab/checkpointing/simple_checkpoint.py
@@ -1,0 +1,221 @@
+
+from mpi4py import MPI
+import json
+import os
+import numpy as np
+import landlab
+from landlab.components import LinearDiffuser
+from landlab.io.native_landlab import save_grid, load_grid
+
+from landlab.io.legacy_vtk import write_legacy_vtk
+
+comm = None
+
+model_grid = None
+elevation = None
+linear_diffuser = None
+checkpoint_index = None
+
+s2yr = 60 * 60 * 24 * 365.25
+timestep = 0
+vtks = []
+
+def initialize(comm_handle):
+    if not comm_handle is None:
+        # Convert the handle back to an MPI communicator
+        global comm
+        comm = MPI.Comm.f2py(comm_handle)
+
+        rank = comm.Get_rank()
+        size = comm.Get_size()
+
+        print(f"Python: Hello from Rank {rank} of {size}")
+
+        data = 1
+        globalsum = comm.allreduce(data, op=MPI.SUM)
+        if comm.rank == 0:
+            print(f"\tPython: testing communication; sum {globalsum}")
+    else:
+        print("Python: running sequentially!")
+
+def finalize():
+    pass
+
+
+# Run the Landlab simulation from the current time to end_time and return
+# the new topographic elevation (in m) at each local node.
+# dict_variable_name_to_value_in_nodes is a dictionary mapping variables
+# (x velocity, y velocity, temperature, etc.) to an array of values in each
+# node.
+def update_until(end_time, current_time, dict_variable_name_to_value_in_nodes):
+    global elevation, linear_diffuser, timestep
+
+    dt = end_time - current_time
+    timestep += 1
+
+    deposition_erosion = np.zeros(model_grid.number_of_nodes)
+
+    # Extract the velocity along the ASPECT model, which is located at y=0 on the landlab mesh.
+    slice_x_velocity = dict_variable_name_to_value_in_nodes["x velocity"]
+    slice_y_velocity = dict_variable_name_to_value_in_nodes["y velocity"]
+
+    # Create empty arrays to project the velocity and composition values out from y=0 to all
+    # nodes on the landlab mesh.
+    vertical_velocity = np.zeros(model_grid.number_of_nodes)
+
+    unique_x_values   = np.unique(model_grid.x_of_node)
+    for x in unique_x_values:
+        vertical_velocity[model_grid.x_of_node == x]  = slice_y_velocity[unique_x_values == x]
+
+    # Substepping for surface processes
+    if dt>0:
+        n_substeps = 10
+        sub_dt = dt / n_substeps
+        for _ in range(n_substeps):
+
+          elevation_before = elevation.copy()
+
+          linear_diffuser.run_one_step(sub_dt)
+
+          elevation += vertical_velocity * sub_dt
+
+          deposition_erosion += elevation - elevation_before
+        pass
+
+    current_time = end_time
+    print("Max elevation:", np.max(elevation), "Min elevation:", np.min(elevation))
+
+    # Return the change in the topography along y=0, where the ASPECT mesh is located.
+    deposition_erosion_2d = np.zeros(len(np.unique(model_grid.x_of_node)))
+    for x in unique_x_values:
+        deposition_erosion_2d = deposition_erosion[model_grid.y_of_node == 0]
+    
+    return deposition_erosion_2d
+
+def set_mesh_information(dict_grid_information):
+    global model_grid, elevation
+
+    if not model_grid:
+        print("* Creating RasterModelGrid ...")
+        x_extent = 100e3
+        y_extent = 100e3
+        spacing  = 500.0
+
+        nrows = int(y_extent / spacing) + 1 # number of node rows
+        ncols = int(x_extent / spacing) + 1 # number of node columns
+
+        model_grid = landlab.RasterModelGrid((nrows, ncols), xy_spacing=(spacing, spacing), xy_of_lower_left=(0, -y_extent / 2))
+
+        print("* Creating topographic elevation ...")
+        # Initialize topography array with zeros
+        elevation = model_grid.add_zeros("topographic__elevation", at="node")
+
+        # Add a large 20 km high triangular mountain in the middle of the LandLab domain.
+        topo_height = 20e3
+        left_x_arr = np.array([25e3, 50e3])
+        left_y_arr = np.array([0.0, topo_height])
+
+        right_x_arr = np.array([50e3, 75e3])
+        right_y_arr = np.array([topo_height, 0.0])
+
+        left_m, left_b = np.polyfit(left_x_arr, left_y_arr, deg=1)
+        right_m, right_b = np.polyfit(right_x_arr, right_y_arr, deg=1)
+
+        elevation[model_grid.x_of_node <= 50e3] = left_m * model_grid.x_of_node[model_grid.x_of_node <= 50e3] + left_b
+        elevation[model_grid.x_of_node > 50e3]  = right_m * model_grid.x_of_node[model_grid.x_of_node > 50e3] + right_b
+
+        elevation[model_grid.x_of_node < np.min(left_x_arr)] = 0.0
+        elevation[model_grid.x_of_node > np.max(right_x_arr)] = 0.0
+
+        # Close all boundaries
+        model_grid.set_closed_boundaries_at_grid_edges(right_is_closed=True, 
+                                                       left_is_closed=True, 
+                                                       top_is_closed=True, 
+                                                       bottom_is_closed=True)
+                                                       
+        print("\tnumber of nodes:", model_grid.number_of_nodes)
+        initialize_landlab_components(None)
+
+        print("* Done")
+
+# If the ASPECT mesh is 2D, then we only want to return the unique values of x on the LandLab mesh,
+# the logic here is probably different if the LandLab mesh is not a raster.
+def get_grid_x(grid_dictionary):
+    global model_grid
+    return np.unique(model_grid.x_of_node)
+
+# If the ASPECT mesh is 2D, then we only return an array of 0s for the y values, since this is where
+# the ASPECT surface is located.
+def get_grid_y(grid_dictionary):
+    global model_grid
+    return np.zeros(np.unique(model_grid.x_of_node).shape)
+
+def initialize_landlab_components(landlab_component_parameters):
+    global model_grid, elevation, linear_diffuser
+
+    D_val = 10 / s2yr
+    linear_diffuser = LinearDiffuser(model_grid, linear_diffusivity=D_val)
+    pass
+
+# Return the initial topography along y=0, where the ASPECT surface is located.
+def get_initial_topography(grid_dictionary):
+    global elevation
+    return elevation[model_grid.y_of_node == 0]
+
+
+def checkpoint(checkpoint_dict):
+    global model_grid, checkpoint_index
+
+    # Extract checkpointing information from the checkpoint dictionary
+    checkpoint_index      = checkpoint_dict["Current checkpoint ID"]
+    output_directory      = checkpoint_dict["Output directory"]
+
+    # Create LandLab checkpoint directory within the ASPECT output directory.
+    output_directory = os.path.join(output_directory, "landlab_checkpoints")
+    os.makedirs(output_directory, exist_ok=True)
+
+    print("Checkpointing the LandLab model grid...")
+    filename = os.path.join(output_directory, f"landlab_checkpoint_{str(checkpoint_index).zfill(2)}.grid")
+    save_grid(model_grid, filename, clobber=True)
+    pass
+
+def resume_checkpoint(checkpoint_dict):
+    global model_grid, elevation, checkpoint_index
+
+    restart_checkpoint_id = checkpoint_dict["Resume checkpoint ID"]
+
+    # Extract checkpointing information from the checkpoint dictionary
+    output_directory = checkpoint_dict["Output directory"]
+    output_directory = os.path.join(output_directory, "landlab_checkpoints")
+
+    # Load the LandLab grid from the checkpoint file corresponding to the checkpoint index.
+    print("Loading the LandLab model grid...")
+    filename = os.path.join(output_directory, f"landlab_checkpoint_{str(restart_checkpoint_id).zfill(2)}.grid")
+    model_grid = load_grid(filename)
+    elevation = model_grid.at_node["topographic__elevation"]
+
+    # We need to initialize the components after loading the LandLab grid, since these
+    # are not stored.
+    initialize_landlab_components(None)
+    pass
+
+def write_output(timestep):
+    # Write the grid to vtk
+    print("Writing output VTK file...")
+    vtk_file = write_legacy_vtk(path=f"./output_{str(timestep).zfill(3)}.vtk", grid=model_grid, clobber=True)
+
+if __name__ == "__main__":
+    comm = MPI.COMM_WORLD
+    initialize(MPI.Comm.py2f(comm))
+
+    set_mesh_information({})
+    initialize_landlab_components(None)
+
+     # Main simulation loop
+    for n in range(100):
+        data = {}
+        data["x velocity"] = np.zeros(model_grid.number_of_nodes)
+        data["y velocity"] = np.zeros(model_grid.number_of_nodes)
+        data["z velocity"] = np.zeros(model_grid.number_of_nodes)
+        update_until(n*dt, data)
+        write_output(n)

--- a/cookbooks/landlab/composition-coupling/variable-diffusivity.py
+++ b/cookbooks/landlab/composition-coupling/variable-diffusivity.py
@@ -8,7 +8,6 @@ from landlab.components import LinearDiffuser
 
 from landlab.io.legacy_vtk import write_legacy_vtk
 
-current_time = 0
 
 comm = None
 
@@ -48,8 +47,8 @@ def finalize():
 # dict_variable_name_to_value_in_nodes is a dictionary mapping variables
 # (x velocity, y velocity, temperature, etc.) to an array of values in each
 # node.
-def update_until(end_time, dict_variable_name_to_value_in_nodes):
-    global current_time, elevation, linear_diffuser, timestep, Diffusivity
+def update_until(end_time, current_time, dict_variable_name_to_value_in_nodes):
+    global elevation, linear_diffuser, timestep, Diffusivity
 
     dt = end_time - current_time
     timestep += 1
@@ -204,5 +203,5 @@ if __name__ == "__main__":
         data["x velocity"] = np.zeros(model_grid.number_of_nodes)
         data["y velocity"] = np.zeros(model_grid.number_of_nodes)
         data["z velocity"] = np.zeros(model_grid.number_of_nodes)
-        update_until(n*dt, data)
+        update_until((n+1)*dt, n*dt, data)
         write_output(n)

--- a/cookbooks/landlab/coupled1/test1.py
+++ b/cookbooks/landlab/coupled1/test1.py
@@ -5,8 +5,6 @@ import numpy as np
 import landlab
 from landlab.components import LinearDiffuser
 
-current_time = 0
-
 comm = None
 
 model_grid = None
@@ -40,8 +38,8 @@ def finalize():
 # dict_variable_name_to_value_in_nodes is a dictionary mapping variables
 # (x velocity, y velocity, temperature, etc.) to an array of values in each
 # node.
-def update_until(end_time, dict_variable_name_to_value_in_nodes):
-    global current_time, elevation, linear_diffuser
+def update_until(end_time, current_time, dict_variable_name_to_value_in_nodes):
+    global elevation, linear_diffuser
     aspect_dt = end_time - current_time
     
     deposition_erosion = np.zeros(model_grid.number_of_nodes)
@@ -119,5 +117,5 @@ if __name__ == "__main__":
         data["x velocity"] = np.zeros(model_grid.number_of_nodes)
         data["y velocity"] = np.zeros(model_grid.number_of_nodes)
         data["z velocity"] = np.zeros(model_grid.number_of_nodes)
-        update_until(n*dt, data)
+        update_until((n+1)*dt, n*dt, data)
         write_output()

--- a/cookbooks/landlab/coupled1/test2.py
+++ b/cookbooks/landlab/coupled1/test2.py
@@ -10,7 +10,6 @@ from landlab.components import FlowAccumulator
 from landlab.components import StreamPowerEroder
 from landlab.io.legacy_vtk import write_legacy_vtk
 
-current_time = 0
 
 comm = None
 
@@ -51,8 +50,8 @@ def finalize():
 # dict_variable_name_to_value_in_nodes is a dictionary mapping variables
 # (x velocity, y velocity, temperature, etc.) to an array of values in each
 # node.
-def update_until(end_time, dict_variable_name_to_value_in_nodes):
-    global current_time, elevation, linear_diffuser, flow_accumulator, stream_power_eroder, timestep
+def update_until(end_time, current_time, dict_variable_name_to_value_in_nodes):
+    global elevation, linear_diffuser, flow_accumulator, stream_power_eroder, timestep
     aspect_dt = end_time - current_time
     timestep += 1
     
@@ -175,5 +174,5 @@ if __name__ == "__main__":
         data["x velocity"] = np.zeros(model_grid.number_of_nodes)
         data["y velocity"] = np.zeros(model_grid.number_of_nodes)
         data["z velocity"] = np.zeros(model_grid.number_of_nodes)
-        update_until(n*dt, data)
+        update_until((n+1)*dt, n*dt, data)
         write_output(n)

--- a/cookbooks/landlab/spherical/spherical_landlab.py
+++ b/cookbooks/landlab/spherical/spherical_landlab.py
@@ -10,8 +10,6 @@ from landlab.components import StreamPowerEroder
 
 from landlab.io.legacy_vtk import write_legacy_vtk
 
-current_time = 0
-
 comm = None
 
 model_grid = None
@@ -58,8 +56,8 @@ def finalize():
 # dict_variable_name_to_value_in_nodes is a dictionary mapping variables
 # (x velocity, y velocity, temperature, etc.) to an array of values in each
 # node.
-def update_until(end_time, dict_variable_name_to_value_in_nodes):
-    global current_time, elevation, linear_diffuser, flow_accumulator, stream_power_eroder, timestep
+def update_until(end_time, current_time, dict_variable_name_to_value_in_nodes):
+    global elevation, linear_diffuser, flow_accumulator, stream_power_eroder, timestep
 
     dt = end_time - current_time
     timestep += 1

--- a/include/aspect/mesh_deformation/landlab.h
+++ b/include/aspect/mesh_deformation/landlab.h
@@ -80,6 +80,19 @@ namespace aspect
                                                    AffineConstraints<double> &constraints) const override;
 
         /**
+         * Save the Landlab state so it can later be restored during restart.
+         */
+        void
+        save (std::map<std::string, std::string> &status_strings) const override;
+
+
+        /**
+         * Restore the Landlab state from a previous checkpoint.
+         */
+        void
+        load (const std::map<std::string, std::string> &status_strings) override;
+
+        /**
          * Declare parameters.
          */
         static
@@ -125,6 +138,7 @@ namespace aspect
          * Whether the ASPECT geometry is spherical.
          */
         bool is_spherical;
+
 #ifdef ASPECT_WITH_PYTHON
         /**
          * The Python module object.

--- a/source/mesh_deformation/landlab.cc
+++ b/source/mesh_deformation/landlab.cc
@@ -18,7 +18,6 @@
   <http://www.gnu.org/licenses/>.
  */
 
-
 #include <aspect/mesh_deformation/landlab.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/patterns.h>
@@ -168,11 +167,12 @@ namespace aspect
             }
 
           {
-            // set_mesh_information: call with None
+            // Initialize the Landlab model grid if needed. The Python side can
+            // guard against recreating it when a restart has already loaded state.
             PyObject *pArgs = PyTuple_Pack(1, Py_None);
             PyObject *pValue = call_python_function(pModule, "set_mesh_information", pArgs);
-            Py_DECREF(pArgs);
             Py_DECREF(pValue);
+            Py_DECREF(pArgs);
           }
 
           {
@@ -243,6 +243,7 @@ namespace aspect
         {
           // Build a dictionary with solution values for each variable to pass to Python:
           PyObject *pDict = PyDict_New();
+
           std::vector<std::string> variable_names = { "x velocity", "y velocity"};
           if (dim == 3)
             variable_names.push_back("z velocity");
@@ -269,7 +270,8 @@ namespace aspect
             }
 
           // Call update_until()
-          PyObject *pArgs = PyTuple_Pack(2, PyFloat_FromDouble(this->get_time()), pDict);
+          const double landlab_time = this->get_time() - this->get_timestep();
+          PyObject *pArgs = PyTuple_Pack(3, PyFloat_FromDouble(this->get_time()), PyFloat_FromDouble(landlab_time), pDict);
           PyObject *pValue = call_python_function(pModule, "update_until", pArgs);
           Py_DECREF(pDict);
           Py_DECREF(pArgs);
@@ -289,6 +291,8 @@ namespace aspect
 
           Py_DECREF(pValue);
         }
+
+
 
       // Produce debug output as a vtu file
 #if DEAL_II_VERSION_GTE(9,8,0)
@@ -404,6 +408,64 @@ namespace aspect
 #endif
     }
 
+
+    template <int dim>
+    void
+    Landlab<dim>::save (std::map<std::string, std::string> &status_strings) const
+    {
+#ifdef ASPECT_WITH_PYTHON
+      if (this_rank_runs_landlab)
+        {
+          const unsigned int checkpoint_id = this->get_checkpoint_id();
+
+          PyObject *pDict = PyDict_New();
+          PyDict_SetItemString(pDict, "Current checkpoint ID", PyLong_FromLong(checkpoint_id));
+          PyDict_SetItemString(pDict, "Output directory", PyUnicode_FromString(this->get_output_directory().c_str()));
+
+          PyObject *pArgs = PyTuple_Pack(1,
+                                         pDict
+                                        );
+          Py_DECREF(pDict);
+          PyObject *pValue = call_python_function(pModule, "checkpoint", pArgs);
+          Py_DECREF(pArgs);
+          Py_DECREF(pValue);
+          status_strings["Landlab Checkpoint ID"] = std::to_string(checkpoint_id);
+        }
+#else
+      (void)status_strings;
+#endif
+    }
+
+
+    template <int dim>
+    void
+    Landlab<dim>::load (const std::map<std::string, std::string> &status_strings)
+    {
+      AssertThrow(status_strings.find("Landlab Checkpoint ID") != status_strings.end(),
+                  ExcMessage("Trying to load data for Landlab from a checkpoint, but no data seems to have been written."));
+
+#ifdef ASPECT_WITH_PYTHON
+      if (this_rank_runs_landlab)
+        {
+          // Check to see whether ASPECT is restarting from a user defined checkpoint, or from the most recent checkpoint.
+          const unsigned int resume_checkpoint_id = this->get_parameters().resume_checkpoint_id == 0 ?
+                                                    std::stoi(status_strings.at("Landlab Checkpoint ID")) :
+                                                    this->get_parameters().resume_checkpoint_id;
+
+          PyObject *pDict = PyDict_New();
+          PyDict_SetItemString(pDict, "Output directory", PyUnicode_FromString(this->get_output_directory().c_str()));
+          PyDict_SetItemString(pDict, "Resume checkpoint ID", PyLong_FromLong(resume_checkpoint_id));
+
+          PyObject *pArgs = PyTuple_Pack(1,
+                                         pDict
+                                        );
+          Py_DECREF(pDict);
+          PyObject *pValue = call_python_function(pModule, "resume_checkpoint", pArgs);
+          Py_DECREF(pArgs);
+          Py_DECREF(pValue);
+        }
+#endif
+    }
 
 
     template <int dim>

--- a/source/mesh_deformation/landlab.cc
+++ b/source/mesh_deformation/landlab.cc
@@ -18,7 +18,6 @@
   <http://www.gnu.org/licenses/>.
  */
 
-
 #include <aspect/mesh_deformation/landlab.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/patterns.h>
@@ -169,11 +168,12 @@ namespace aspect
             }
 
           {
-            // set_mesh_information: call with None
+            // Initialize the Landlab model grid if needed. The Python side can
+            // guard against recreating it when a restart has already loaded state.
             PyObject *pArgs = PyTuple_Pack(1, Py_None);
             PyObject *pValue = call_python_function(pModule, "set_mesh_information", pArgs);
-            Py_DECREF(pArgs);
             Py_DECREF(pValue);
+            Py_DECREF(pArgs);
           }
 
           {
@@ -244,6 +244,7 @@ namespace aspect
         {
           // Build a dictionary with solution values for each variable to pass to Python:
           PyObject *pDict = PyDict_New();
+
           std::vector<std::string> variable_names = { "x velocity", "y velocity"};
           if (dim == 3)
             variable_names.push_back("z velocity");
@@ -270,7 +271,8 @@ namespace aspect
             }
 
           // Call update_until()
-          PyObject *pArgs = PyTuple_Pack(3, PyFloat_FromDouble(this->get_time()), PyLong_FromLong(dim), pDict);
+          const double landlab_time = this->get_time() - this->get_timestep();
+          PyObject *pArgs = PyTuple_Pack(4, PyFloat_FromDouble(this->get_time()), PyFloat_FromDouble(landlab_time), PyLong_FromLong(dim), pDict);
           PyObject *pValue = call_python_function(pModule, "update_until", pArgs);
           Py_DECREF(pDict);
           Py_DECREF(pArgs);
@@ -290,6 +292,8 @@ namespace aspect
 
           Py_DECREF(pValue);
         }
+
+
 
       // Produce debug output as a vtu file
 #if DEAL_II_VERSION_GTE(9,8,0)
@@ -399,6 +403,64 @@ namespace aspect
 #endif
     }
 
+
+    template <int dim>
+    void
+    Landlab<dim>::save (std::map<std::string, std::string> &status_strings) const
+    {
+#ifdef ASPECT_WITH_PYTHON
+      if (this_rank_runs_landlab)
+        {
+          const unsigned int checkpoint_id = this->get_checkpoint_id();
+
+          PyObject *pDict = PyDict_New();
+          PyDict_SetItemString(pDict, "Current checkpoint ID", PyLong_FromLong(checkpoint_id));
+          PyDict_SetItemString(pDict, "Output directory", PyUnicode_FromString(this->get_output_directory().c_str()));
+
+          PyObject *pArgs = PyTuple_Pack(1,
+                                         pDict
+                                        );
+          Py_DECREF(pDict);
+          PyObject *pValue = call_python_function(pModule, "checkpoint", pArgs);
+          Py_DECREF(pArgs);
+          Py_DECREF(pValue);
+          status_strings["Landlab Checkpoint ID"] = std::to_string(checkpoint_id);
+        }
+#else
+      (void)status_strings;
+#endif
+    }
+
+
+    template <int dim>
+    void
+    Landlab<dim>::load (const std::map<std::string, std::string> &status_strings)
+    {
+      AssertThrow(status_strings.find("Landlab Checkpoint ID") != status_strings.end(),
+                  ExcMessage("Trying to load data for Landlab from a checkpoint, but no data seems to have been written."));
+
+#ifdef ASPECT_WITH_PYTHON
+      if (this_rank_runs_landlab)
+        {
+          // Check to see whether ASPECT is restarting from a user defined checkpoint, or from the most recent checkpoint.
+          const unsigned int resume_checkpoint_id = this->get_parameters().resume_checkpoint_id == 0 ?
+                                                    std::stoi(status_strings.at("Landlab Checkpoint ID")) :
+                                                    this->get_parameters().resume_checkpoint_id;
+
+          PyObject *pDict = PyDict_New();
+          PyDict_SetItemString(pDict, "Output directory", PyUnicode_FromString(this->get_output_directory().c_str()));
+          PyDict_SetItemString(pDict, "Resume checkpoint ID", PyLong_FromLong(resume_checkpoint_id));
+
+          PyObject *pArgs = PyTuple_Pack(1,
+                                         pDict
+                                        );
+          Py_DECREF(pDict);
+          PyObject *pValue = call_python_function(pModule, "resume_checkpoint", pArgs);
+          Py_DECREF(pArgs);
+          Py_DECREF(pValue);
+        }
+#endif
+    }
 
 
     template <int dim>

--- a/tests/mesh_deformation_external_landlab_01.py
+++ b/tests/mesh_deformation_external_landlab_01.py
@@ -5,8 +5,6 @@ import numpy as np
 import landlab
 from landlab.components import LinearDiffuser
 
-current_time = 0
-
 comm = None
 
 mg = None
@@ -38,8 +36,7 @@ def finalize():
 # dict_variable_name_to_value_in_nodes is a dictionary mapping variables
 # (x velocity, y velocity, temperature, etc.) to an array of values in each
 # node.
-def update_until(end_time, dict_variable_name_to_value_in_nodes):
-    global current_time
+def update_until(end_time, current_time, dict_variable_name_to_value_in_nodes):
     dt = end_time - current_time
     
     deposition_erosion = np.zeros(mg.number_of_nodes)
@@ -124,5 +121,5 @@ if __name__ == "__main__":
         data["x velocity"] = np.zeros(mg.number_of_nodes)
         data["y velocity"] = np.zeros(mg.number_of_nodes)
         data["z velocity"] = np.zeros(mg.number_of_nodes)
-        update_until(n*dt, data)
+        update_until((n+1)*dt, n*dt, data)
         write_output()

--- a/tests/mesh_deformation_external_landlab_01.py
+++ b/tests/mesh_deformation_external_landlab_01.py
@@ -5,8 +5,6 @@ import numpy as np
 import landlab
 from landlab.components import LinearDiffuser
 
-current_time = 0
-
 comm = None
 
 mg = None
@@ -38,8 +36,7 @@ def finalize():
 # dict_variable_name_to_value_in_nodes is a dictionary mapping variables
 # (x velocity, y velocity, temperature, etc.) to an array of values in each
 # node.
-def update_until(end_time, ASPECT_dim, dict_variable_name_to_value_in_nodes):
-    global current_time
+def update_until(end_time, current_time, ASPECT_dim, dict_variable_name_to_value_in_nodes):
     dt = end_time - current_time
     
     deposition_erosion = np.zeros(mg.number_of_nodes)
@@ -124,5 +121,5 @@ if __name__ == "__main__":
         data["x velocity"] = np.zeros(mg.number_of_nodes)
         data["y velocity"] = np.zeros(mg.number_of_nodes)
         data["z velocity"] = np.zeros(mg.number_of_nodes)
-        update_until(n*dt, data)
+        update_until((n+1)*dt, n*dt, 2, data)
         write_output()

--- a/tests/mesh_deformation_external_landlab_02.py
+++ b/tests/mesh_deformation_external_landlab_02.py
@@ -3,8 +3,6 @@ print("mesh_deformation_external_landlab_02.py")
 from mpi4py import MPI
 import numpy as np
 
-current_time = 0
-
 comm = None
 
 
@@ -48,7 +46,7 @@ def finalize():
 # dict_variable_name_to_value_in_nodes is a dictionary mapping variables
 # (x velocity, y velocity, temperature, etc.) to an array of values in each
 # node.
-def update_until(end_time, dict_variable_name_to_value_in_nodes):
+def update_until(end_time, current_time, dict_variable_name_to_value_in_nodes):
 
     print(f"update_until: end_time = {end_time}")
    
@@ -92,5 +90,5 @@ if __name__ == "__main__":
         data["x velocity"] = np.zeros(px.size)
         data["y velocity"] = np.zeros(px.size)
         data["z velocity"] = np.zeros(px.size)
-        update_until(n*dt, data)
+        update_until((n+1)*dt, n*dt, data)
         write_output()

--- a/tests/mesh_deformation_external_landlab_02.py
+++ b/tests/mesh_deformation_external_landlab_02.py
@@ -3,8 +3,6 @@ print("mesh_deformation_external_landlab_02.py")
 from mpi4py import MPI
 import numpy as np
 
-current_time = 0
-
 comm = None
 
 
@@ -48,7 +46,7 @@ def finalize():
 # dict_variable_name_to_value_in_nodes is a dictionary mapping variables
 # (x velocity, y velocity, temperature, etc.) to an array of values in each
 # node.
-def update_until(end_time, ASPECT_dim, dict_variable_name_to_value_in_nodes):
+def update_until(end_time, current_time, ASPECT_dim, dict_variable_name_to_value_in_nodes):
 
     print(f"update_until: end_time = {end_time}")
    
@@ -92,5 +90,5 @@ if __name__ == "__main__":
         data["x velocity"] = np.zeros(px.size)
         data["y velocity"] = np.zeros(px.size)
         data["z velocity"] = np.zeros(px.size)
-        update_until(n*dt, data)
+        update_until((n+1)*dt, n*dt, 2, data)
         write_output()


### PR DESCRIPTION
This PR adds two new functions to the landlab mesh deformation plugin, one that checkpoints the landlab grid and one that loads in the landlab grid.

This is not generalized at the moment, and only works based on the `Checkpointing.Steps between checkpoint` parameter, and not the `Checkpointing.Time between checkpoint` parameter. 

My understanding of the save/load grid functions in LandLab is that it stores all of the grid properties. This means that the size of the mesh, the links, and assosciated fields (drainage_area, topographic__elevation) are stored, but not the components. Therefore, if a grid file is loaded, the LandLab components need to be reinitialized.

The new code checks to see if ASPECT is writing a checkpoint, and if it is then `checkpoint_landlab()` is called and the landlab grid file is saved. If ASPECT is being restarted, then `restart_landlab()` is called in `update()` instead of calling the `set_mesh_information` function in the python file. 

This isn't working perfectly, but it's currently an improvement over what happened previously. Below is showing an animation where a simple mountain diffusion model restarts at t=5 Myr. Clearly there's a catastrohpic numerical error that occurs when the model is restarted.

![wrong](https://github.com/user-attachments/assets/cc94e2e5-268a-4d1f-a6c6-5be47d13877a)

With what is added here, the below animation shows what happens when restarting from a checkpoint. Here the model restarts at t=1 Myr, and there's still a visible jump in the model at this time, but the difference is minor. I'm optimistic this is just a mismatch in the timing of the ASPECT checkpoint and the LandLab checkpoint.

![animation](https://github.com/user-attachments/assets/f81b5ee9-9019-49e1-8474-c8d72a288827)

