### PR TITLE
Create write_output Function

### DIFF
--- a/cookbooks/landlab/postprocess/postprocess-test.prm
+++ b/cookbooks/landlab/postprocess/postprocess-test.prm
@@ -1,0 +1,186 @@
+# This cookbook is used as a test to ensure that FastScape is properly working with ASPECT.
+# It consists of a 2.5 km high central mountain block that is eroded through the use of
+# hillslope diffusion and the Stream Power Law. Within ASPECT, the model is based off
+# convection-box-3d. However, it is set up in a way that nothing happens in the geodynamic model.
+
+# At the top, we define the number of space dimensions we would like to
+# work in:
+set Dimension                              = 2
+set Use years instead of seconds           = true
+# set End time                               = 5e6
+set End time                               = 1e6
+set Maximum time step                      = 1e4
+set Output directory                       = postprocessing-test
+set Pressure normalization                 = no
+set Surface pressure                       = 0
+set Resume computation                     = false
+set Nonlinear solver scheme                = iterated Advection and Stokes
+
+subsection Checkpointing
+  # set Time between checkpoint = 1
+  set Steps between checkpoint = 1
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block AMG
+  end
+end
+
+subsection Discretization
+  set Composition polynomial degree           = 2
+  set Stokes velocity polynomial degree       = 2
+  set Temperature polynomial degree           = 2
+  set Use discontinuous composition discretization = true
+end
+
+# A box that has an initial 60x60 km mountain block that is 2.5 km above the initial model surface.
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 100e3
+    set Y extent = 25e3
+
+    set X repetitions = 4
+    set Y repetitions = 1
+  end
+end
+
+# We do not consider temperature in this setup
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = bottom, top
+  set List of model names = initial temperature
+end
+
+# X Set all boundaries except the top to freeslip.
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = bottom:function, left:function, right:function #, front:function, back:function
+  subsection Function
+    set Coordinate system   = cartesian
+    set Variable names      = x,y,t
+    set Function constants  = uplift_rate=0, cm=0.0
+    set Function expression = 0; uplift_rate * cm
+  end
+end
+
+# subsection Boundary traction model
+#   set Prescribed traction boundary indicators = right: initial lithostatic pressure, left: initial lithostatic pressure
+#   subsection Initial lithostatic pressure
+#     set Number of integration points = 10000
+#     set Representative point         = 0.0, 0.0
+#   end
+# end
+
+# Here we setup the top boundary with fastscape.
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: Landlab
+  set Additional tangential mesh velocity boundary indicators = left, right
+
+  subsection Landlab
+    set MPI ranks for Landlab = 1
+    set Script name           = postprocess
+    set Script argument       =
+    set Script path           =
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 1e-100
+  end
+end
+
+# Dimensionless
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 1
+    set Thermal expansion coefficient = 1
+    set Viscosity                     = 1
+  end
+end
+
+# We also have to specify that we want to use the Boussinesq
+# approximation (assuming the density in the temperature
+# equation to be constant, and incompressibility).
+subsection Formulation
+  set Formulation = Boussinesq approximation
+end
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Compositional field methods =  field, field
+  set Types of fields =  chemical composition,  chemical composition
+  set Names of fields = strong, weak
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Coordinate system   =  cartesian
+    set Variable names      =  x,y,t
+    set Function expression = if(x>=50e3, 0.0, 1.0); if(x<=50e3, 0.0, 1.0)
+  end
+end
+
+subsection Boundary composition model
+  set Fixed composition boundary indicators         = bottom, top
+  set List of model names                           =  initial composition
+  set Allow fixed composition on outflow boundaries = true
+end
+
+
+# We set a maximum surface refinement level of 4 using the max/minimum refinement level.
+# This will make it so that the ASPECT surface refinement is the same as what we set
+# for our maximum surface refinement level for FastScape.
+subsection Mesh refinement
+  set Initial global refinement                = 3
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+#   set Strategy                                 = minimum refinement function, maximum refinement function
+
+#   subsection Maximum refinement function
+#     set Coordinate system   = cartesian
+#     set Variable names      = x,y,z
+#     set Function expression = if(y>=21000, 4, 2)
+#   end
+
+#   subsection Minimum refinement function
+#     set Coordinate system   = cartesian
+#     set Variable names      = x,y,z
+#     set Function expression = if(y>=21000, 4, 2)
+#   end
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, topography, velocity statistics, composition statistics
+
+  subsection Topography
+    set Output to file = true
+    set Time between text output = 50e3
+  end
+
+  subsection Visualization
+    set Time between graphical output = 50e3
+    set Output mesh velocity = true
+    set Output mesh displacement = true
+    set Output undeformed mesh = false
+    set Interpolate output = false
+  end
+
+end

--- a/cookbooks/landlab/postprocess/postprocess.py
+++ b/cookbooks/landlab/postprocess/postprocess.py
@@ -1,0 +1,206 @@
+
+from mpi4py import MPI
+import json
+import os
+import numpy as np
+import landlab
+from landlab.components import LinearDiffuser
+
+from landlab.io.native_landlab import save_grid, load_grid
+
+from landlab.io.legacy_vtk import write_legacy_vtk
+
+current_time = 0
+comm = None
+
+model_grid = None
+elevation  = None
+
+linear_diffuser    = None
+
+s2yr = 60 * 60 * 24 * 365.25
+timestep = 0
+vtks = []
+
+def initialize(comm_handle):
+    if not comm_handle is None:
+        # Convert the handle back to an MPI communicator
+        global comm
+        comm = MPI.Comm.f2py(comm_handle)
+
+        rank = comm.Get_rank()
+        size = comm.Get_size()
+
+        print(f"Python: Hello from Rank {rank} of {size}")
+
+        data = 1
+        globalsum = comm.allreduce(data, op=MPI.SUM)
+        if comm.rank == 0:
+            print(f"\tPython: testing communication; sum {globalsum}")
+    else:
+        print("Python: running sequentially!")
+
+def finalize():
+    pass
+
+
+# Run the Landlab simulation from the current time to end_time and return
+# the new topographic elevation (in m) at each local node.
+# dict_variable_name_to_value_in_nodes is a dictionary mapping variables
+# (x velocity, y velocity, temperature, etc.) to an array of values in each
+# node.
+def update_until(end_time, dict_variable_name_to_value_in_nodes):
+    global elevation, linear_diffuser, timestep, current_time
+
+    dt = end_time - current_time
+    timestep += 1
+
+    deposition_erosion = np.zeros(model_grid.number_of_nodes)
+
+    # Extract the velocity along the ASPECT model, which is located at y=0 on the landlab mesh.
+    slice_x_velocity = dict_variable_name_to_value_in_nodes["x velocity"]
+    slice_y_velocity = dict_variable_name_to_value_in_nodes["y velocity"]
+
+    # Create empty arrays to project the velocity and composition values out from y=0 to all
+    # nodes on the landlab mesh.
+    vertical_velocity = np.zeros(model_grid.number_of_nodes)
+
+    unique_x_values   = np.unique(model_grid.x_of_node)
+    for x in unique_x_values:
+        vertical_velocity[model_grid.x_of_node == x]  = slice_y_velocity[unique_x_values == x]
+
+    # Substepping for surface processes
+    if dt>0:
+        n_substeps = 10
+        sub_dt = dt / n_substeps
+        for _ in range(n_substeps):
+
+          elevation_before = elevation.copy()
+          linear_diffuser.run_one_step(sub_dt)
+
+          elevation[model_grid.core_nodes] += vertical_velocity[model_grid.core_nodes] * sub_dt
+
+          deposition_erosion += elevation - elevation_before
+        pass
+
+    current_time = end_time
+    print("Min elevation", np.min(elevation), "Max elevation:", np.max(elevation))
+
+    deposition_erosion_2d = np.zeros(len(np.unique(model_grid.x_of_node)))
+    for x in unique_x_values:
+        deposition_erosion_2d[unique_x_values == x] = np.average(deposition_erosion[model_grid.x_of_node == x])
+    
+    return deposition_erosion_2d
+
+def set_mesh_information(dict_grid_information):
+    global model_grid, elevation
+
+    if not model_grid:
+        print("* Creating RasterModelGrid ...")
+        x_extent = 100e3
+        y_extent = 100e3
+        spacing  = 1000.0
+
+        nrows = int(y_extent / spacing) + 3 # number of node rows
+        ncols = int(x_extent / spacing) + 3 # number of node columns
+
+        model_grid = landlab.RasterModelGrid((nrows, ncols), xy_spacing=(spacing, spacing), xy_of_lower_left=(-spacing, -y_extent / 2 - spacing))
+
+        print("* Creating topographic elevation ...")
+        # Initialize topography array with zeros
+        elevation = model_grid.add_zeros("topographic__elevation", at="node")
+        elevation += np.sin(np.pi * model_grid.x_of_node / x_extent) * 10000.0
+
+        # Close all boundaries
+        model_grid.set_closed_boundaries_at_grid_edges(right_is_closed=True, 
+                                                       left_is_closed=True, 
+                                                       top_is_closed=True, 
+                                                       bottom_is_closed=True)
+                                                       
+        print("\tnumber of nodes:", model_grid.number_of_nodes)
+
+        initialize_landlab_components(None)
+
+        print("* Done")
+
+# If the ASPECT mesh is 2D, then we only want to return the unique values of x on the LandLab mesh,
+# the logic here is probably different if the LandLab mesh is not a raster.
+def get_grid_x(grid_dictionary):
+    global model_grid
+    return np.unique(model_grid.x_of_node)
+
+# If the ASPECT mesh is 2D, then we only return an array of 0s for the y values, since this is where
+# the ASPECT surface is located.
+def get_grid_y(grid_dictionary):
+    global model_grid
+    return np.zeros(np.unique(model_grid.x_of_node).shape)
+
+def initialize_landlab_components(landlab_component_parameters):
+    global model_grid, elevation, linear_diffuser
+
+    D_val = 1000 / s2yr
+
+    print("* Initializing Landlab components ...")
+    linear_diffuser     = LinearDiffuser(model_grid, linear_diffusivity=D_val)
+    print("* Done initializing Landlab components")
+
+    pass
+
+def checkpoint_model_grid():
+    global model_grid
+
+    print("Checkpointing the LandLab model grid...")
+    filename = "./landlab_model_grid_checkpoint.grid"
+    save_grid(model_grid, filename, clobber=True)
+    pass
+
+def load_model_grid():
+    global model_grid, elevation
+
+    print("Loading the LandLab model grid...")
+    filename = "./landlab_model_grid_checkpoint.grid"
+    model_grid = load_grid(filename)
+    elevation = model_grid.at_node["topographic__elevation"]
+
+    # We need to initialize the components after loading the LandLab grid, since these
+    # are not stored.
+    initialize_landlab_components(None)
+    pass
+
+# Return the initial topography along y=0, where the ASPECT surface is located.
+def get_initial_topography(grid_dictionary):
+    global elevation
+    return elevation[model_grid.y_of_node == 0]
+
+def write_output(postprocess_dictionary):
+    global model_grid
+
+    timestep = postprocess_dictionary["ASPECT timestep"]
+    current_time = postprocess_dictionary["ASPECT time"]
+    output_directory = postprocess_dictionary["ASPECT output directory"]
+    landlab_output_directory = os.path.join(output_directory, "landlab")
+
+    LandLab_output_frequency = 10
+    if timestep % LandLab_output_frequency != 0:
+        return
+
+    if not os.path.isdir(landlab_output_directory):
+        os.makedirs(landlab_output_directory, exist_ok=True)
+
+    # Write the grid to vtk
+    filename = os.path.join(landlab_output_directory, f"landlab_{str(timestep).zfill(3)}.vtk")
+    print("Writing output VTK file...", filename)
+    vtk_file = write_legacy_vtk(path=filename, grid=model_grid, clobber=True)
+    vtks.append((current_time, filename))
+
+    if True:
+        # write vtk.series file (ParaView supports legacy VTK in this format)
+        with open(f"{output_directory}/landlab.vtk.series", "w") as f:
+            series = {
+                "file-series-version": "1.0",
+                "files": [
+                    {"name": os.path.basename(filename), "time": time}
+                    for time, filename in vtks
+                ]
+            }
+            json.dump(series, f, indent=2)

--- a/include/aspect/mesh_deformation/landlab.h
+++ b/include/aspect/mesh_deformation/landlab.h
@@ -80,6 +80,12 @@ namespace aspect
                                                    AffineConstraints<double> &constraints) const override;
 
         /**
+         * Write output. This calls a function in the Landlab Python module to write output vtk files.
+         */
+        void
+        write_output() const;
+
+        /**
          * Declare parameters.
          */
         static

--- a/source/mesh_deformation/landlab.cc
+++ b/source/mesh_deformation/landlab.cc
@@ -261,6 +261,8 @@ namespace aspect
           Py_DECREF(pDict);
           Py_DECREF(pArgs);
 
+          write_output();
+
           const ArrayView<const double> data = PythonHelper::numpy_to_array_view(pValue);
           const double one_over_dt = 1.0 / ((this->get_timestep() > 0.0) ? this->get_timestep() : 1.0);
           for (size_t i=0; i<data.size(); ++i)
@@ -388,6 +390,33 @@ namespace aspect
       (void)mesh_deformation_dof_handler;
       (void)boundary_indicator;
       (void)constraints;
+#endif
+    }
+
+
+
+    template <int dim>
+    void
+    Landlab<dim>::write_output() const
+    {
+      // Call Python write_output() function with current time as argument
+#ifdef ASPECT_WITH_PYTHON
+      if (this_rank_runs_landlab)
+        {
+
+          PyObject *pDict = PyDict_New();
+          PyDict_SetItemString(pDict, "ASPECT timestep", PyFloat_FromDouble(this->get_timestep_number()));
+          PyDict_SetItemString(pDict, "ASPECT time", PyFloat_FromDouble(this->get_time()));
+          PyDict_SetItemString(pDict, "ASPECT output directory", PyUnicode_FromString(this->get_output_directory().c_str()));
+
+          PyObject *pArgs = PyTuple_Pack(1,
+                                         pDict
+                                        );
+          Py_DECREF(pDict);
+          PyObject *pValue = call_python_function(pModule, "write_output", pArgs);
+          Py_DECREF(pArgs);
+          Py_DECREF(pValue);
+        }
 #endif
     }
 


### PR DESCRIPTION
Now that checkpointing is in a working state, there was an issue with the writing of the landlab VTKs where after a restart the index of the vtk output would be reset to 0. This PR adds a new function that sends the timestep (integer) to landlab so that this issue is avoided. It also sends the ASPECT directory so that the landlab output is always contained within the ASPECT output.

I was debating whether to make a separate visualization plugin to do this, but ultimately decided to do this since it was simpler to implement and also because it's not really an "ASPECT" visualization, it's calling landlab to write it's own output, so putting it within this plugin seemed reasonable.