### PR TITLE
Add a Template Class

### DIFF
--- a/contrib/python/scripts/landlab_template.py
+++ b/contrib/python/scripts/landlab_template.py
@@ -151,23 +151,39 @@ class LandLabTemplate:
     # ---------------------------------------------------------------------------
     # The rest of these functions likely will not require any modification.
     # ---------------------------------------------------------------------------
-    def determine_uplift_velocity(self, ASPECT_dim, dict_variable_name_to_value_in_nodes):
-        """Determine uplift velocity from ASPECT variables."""
+    def determine_uplift_velocity(self, ASPECT_dim, ASPECT_fields_at_Landlab_nodes_dict):
+        """
+        Determine uplift velocity of the Landlab mesh using the ASPECT velocity. In 3D, the vertical velocity is directly obtained 
+        from the z-velocity calculated in ASPECT. In 2D, the vertical velocity is obtained by projecting the y-velocity from the 
+        ASPECT surface (which is expected to be located at y=0 on the Landlab mesh) to all nodes on the Landlab mesh.
+
+        Parameters:
+        - ASPECT_dim: the dimension of the ASPECT model (2 or 3).
+        - ASPECT_fields_at_Landlab_nodes_dict: a dictionary mapping ASPECT variables to values at each node on the Landlab mesh.
+        """
         if ASPECT_dim == 2:
-            slice_y_velocity = dict_variable_name_to_value_in_nodes["y velocity"]
+            slice_y_velocity = ASPECT_fields_at_Landlab_nodes_dict["y velocity"]
 
             vertical_velocity = np.zeros(self.model_grid.number_of_nodes)
             unique_x_values = np.unique(self.model_grid.x_of_node)
             for x in unique_x_values:
                 vertical_velocity[self.model_grid.x_of_node == x] = slice_y_velocity[unique_x_values == x]
         elif ASPECT_dim == 3:
-            vertical_velocity = dict_variable_name_to_value_in_nodes["z velocity"]
+            vertical_velocity = ASPECT_fields_at_Landlab_nodes_dict["z velocity"]
 
         return vertical_velocity
     
-    def determine_horizontal_velocity(self, ASPECT_dim, dict_variable_name_to_value_in_nodes):
-        """Determine horizontal velocity from ASPECT variables."""
-        x_velocity = dict_variable_name_to_value_in_nodes["x velocity"]
+    def determine_horizontal_velocity(self, ASPECT_dim, ASPECT_fields_at_Landlab_nodes_dict):
+        """
+        Determine horizontal velocity from ASPECT variables. In 3D, the horizontal velocity is obtained by directly projecting the 
+        x and y velocity from ASPECT to the links of the Landlab mesh. In 2D, the horizontal velocity is obtained by projecting the 
+        x velocity from ASPECT to the links of the Landlab mesh and setting the y velocity to zero.
+
+        Parameters:
+        - ASPECT_dim: the dimension of the ASPECT model (2 or 3).
+        - ASPECT_fields_at_Landlab_nodes_dict: a dictionary mapping ASPECT variables to values at each node on the Landlab mesh.
+        """
+        x_velocity = ASPECT_fields_at_Landlab_nodes_dict["x velocity"]
 
         if ASPECT_dim == 2:
             projected_x_velocity = np.zeros(self.model_grid.number_of_nodes)
@@ -179,10 +195,10 @@ class LandLabTemplate:
             y_vel_at_links = self.model_grid.map_mean_of_link_nodes_to_link(np.zeros(self.model_grid.number_of_nodes)) # y velocity is zero since the ASPECT model is 2D.
 
         elif ASPECT_dim == 3:
-            y_velocity = dict_variable_name_to_value_in_nodes["y velocity"]
+            y_velocity = ASPECT_fields_at_Landlab_nodes_dict["y velocity"]
 
             x_vel_at_links = self.model_grid.map_mean_of_link_nodes_to_link(x_velocity)
-            y_vel_at_links = self.model_grid.map_mean_of_link_nodes_to_link(y_velocity) # y velocity is zero since the ASPECT model is 2D.
+            y_vel_at_links = self.model_grid.map_mean_of_link_nodes_to_link(y_velocity)
 
         self.horizontal_velocity[self.model_grid.horizontal_links] = x_vel_at_links[self.model_grid.horizontal_links]
         self.horizontal_velocity[self.model_grid.vertical_links]   = y_vel_at_links[self.model_grid.vertical_links]
@@ -190,6 +206,16 @@ class LandLabTemplate:
         return self.horizontal_velocity
 
     def dimensional_deposition_erosion(self, ASPECT_dim, deposition_erosion):
+        """
+        Calculate the change in the topography in a way that is consistent with the dimension expected by the ASPECT model.
+        In 3D, this function returns the change in topography at each node. In 2D, this function averages the change in 
+        topography across the y-direction and returns the change in topography along y=0, where the ASPECT surface is 
+        expected to be located.
+
+        Parameters:
+        - ASPECT_dim: the dimension of the ASPECT model (2 or 3).
+        - deposition_erosion: the change in topography at each node on the Landlab mesh
+        """
         if ASPECT_dim == 2:
             deposition_erosion_2d = np.zeros(len(np.unique(self.model_grid.x_of_node)))
             unique_x_values = np.unique(self.model_grid.x_of_node)
@@ -202,11 +228,20 @@ class LandLabTemplate:
             return deposition_erosion
 
     def checkpoint_model_grid(self):
+        """
+        Checkpoint the Landlab model grid by saving it to a file. This function is called when
+        checkpointing the ASPECT model.
+        """
+
         filename = "./landlab_model_grid_checkpoint.grid"
         save_grid(self.model_grid, filename, clobber=True)
         pass
 
     def load_model_grid(self):
+        """
+        Load the Landlab model grid from a file. This function is called when
+        restarting the ASPECT model from a checkpoint.
+        """
         filename = "./landlab_model_grid_checkpoint.grid"
         self.model_grid = load_grid(filename)
         self.elevation = self.model_grid.at_node["topographic__elevation"]
@@ -214,12 +249,26 @@ class LandLabTemplate:
         pass
 
     def get_initial_topography(self, ASPECT_dim):
+        """
+        Return the initial topography. In 3D, this function returns the initial topography at each node.
+        In 2D, this function returns the initial topography along y=0, where the ASPECT surface is expected to be located.
+
+        Parameters:
+        - ASPECT_dim: the dimension of the ASPECT model (2 or 3).
+        """
         if ASPECT_dim == 2:
             return self.elevation[self.model_grid.y_of_node == 0]
         elif ASPECT_dim == 3:
             return self.elevation
         
     def write_output(self, postprocess_dictionary):
+        """
+        Write output for visualizing the landlab mesh. This calls a function in the Landlab Python module to write output vtk files. 
+        This function is called at the end of each ASPECT timestep after the ASPECT model has been updated and the topography has been evolved.
+
+        Parameters:
+        - postprocess_dictionary: a dictionary containing information about the current ASPECT timestep, time, and output directory.
+        """
         step = postprocess_dictionary["ASPECT timestep"]
         time = postprocess_dictionary["ASPECT time"]
         output_directory = postprocess_dictionary["ASPECT output directory"]
@@ -245,18 +294,38 @@ class LandLabTemplate:
         pass
 
     def get_grid_x(self, ASPECT_dim):
+        """
+        Return the x-coordinates of the grid nodes. In 2D, this function returns the unique x-coordinates.
+        In 3D, this function returns the x-coordinates of all nodes.
+
+        Parameters:
+        - ASPECT_dim: the dimension of the ASPECT model (2 or 3).
+        """
         if ASPECT_dim == 2:
             return np.unique(self.model_grid.x_of_node)
         elif ASPECT_dim == 3:
             return self.model_grid.x_of_node
     
     def get_grid_y(self, ASPECT_dim):
+        """
+        Return the y-coordinates of the grid nodes. In 2D, this function returns an array of zeros equal to 
+        the number of unique x-coordinates. In 3D, this function returns the y-coordinates of all nodes.
+
+        Parameters:
+        - ASPECT_dim: the dimension of the ASPECT model (2 or 3).
+        """
         if ASPECT_dim == 2:
-            return np.unique(self.model_grid.y_of_node)
+            return np.zeros(self.model_grid.y_of_node.size())
         elif ASPECT_dim == 3:
             return self.model_grid.y_of_node
         
     def get_grid_z(self, ASPECT_dim):
+        """
+        Return the z-coordinates of the grid nodes. This function is only applicable for 3D spherical ASPECT models.
+
+        Parameters:
+        - ASPECT_dim: the dimension of the ASPECT model (2 or 3).
+        """
         if ASPECT_dim == 3:
             return self.model_grid.z_of_node
         else:

--- a/contrib/python/scripts/landlab_template.py
+++ b/contrib/python/scripts/landlab_template.py
@@ -19,7 +19,7 @@ class LandLabTemplate:
     """Template class for LandLab scripts used in ASPECT-Landlab coupling."""
 
     # Functions that actually get called within ASPECT. These functions are checked to ensure
-    # that the signatures of these function are not modified when instantiating this class.
+    # that their signatures are not modified when instantiating this class.
     _signature_checked_methods = (
         "initialize",
         "finalize",
@@ -65,7 +65,6 @@ class LandLabTemplate:
 
         self.horizontal_velocity         = None
         self.horizontal_surface_advector = None
-
 
         self.s2yr = 60 * 60 * 24 * 365.25
         self.timestep = 0
@@ -151,23 +150,46 @@ class LandLabTemplate:
     # ---------------------------------------------------------------------------
     # The rest of these functions likely will not require any modification.
     # ---------------------------------------------------------------------------
-    def determine_uplift_velocity(self, ASPECT_dim, dict_variable_name_to_value_in_nodes):
-        """Determine uplift velocity from ASPECT variables."""
+    def determine_uplift_velocity(self, ASPECT_dim, ASPECT_fields_at_Landlab_nodes_dict):
+        """
+        Determine uplift velocity of the Landlab mesh using the ASPECT velocity. In 3D, the vertical velocity is directly obtained 
+        from the z-velocity calculated in ASPECT. In 2D, the vertical velocity is obtained by projecting the y-velocity from the 
+        ASPECT surface (which is expected to be located at y=0 on the Landlab mesh) to all nodes on the Landlab mesh.
+
+        For a 2D ASPECT model, the coupling currently only supports structured Landlab grids. The velocity from ASPECT is projected
+        across the Landlab grid such that the values from ASPECT are fixed along a given x-value on the Landlab grid.
+
+        Parameters:
+        - ASPECT_dim: the dimension of the ASPECT model (2 or 3).
+        - ASPECT_fields_at_Landlab_nodes_dict: a dictionary mapping ASPECT variables to values at each node on the Landlab mesh.
+        """
         if ASPECT_dim == 2:
-            slice_y_velocity = dict_variable_name_to_value_in_nodes["y velocity"]
+            slice_y_velocity = ASPECT_fields_at_Landlab_nodes_dict["y velocity"]
 
             vertical_velocity = np.zeros(self.model_grid.number_of_nodes)
             unique_x_values = np.unique(self.model_grid.x_of_node)
             for x in unique_x_values:
                 vertical_velocity[self.model_grid.x_of_node == x] = slice_y_velocity[unique_x_values == x]
+
         elif ASPECT_dim == 3:
-            vertical_velocity = dict_variable_name_to_value_in_nodes["z velocity"]
+            vertical_velocity = ASPECT_fields_at_Landlab_nodes_dict["z velocity"]
 
         return vertical_velocity
     
-    def determine_horizontal_velocity(self, ASPECT_dim, dict_variable_name_to_value_in_nodes):
-        """Determine horizontal velocity from ASPECT variables."""
-        x_velocity = dict_variable_name_to_value_in_nodes["x velocity"]
+    def determine_horizontal_velocity(self, ASPECT_dim, ASPECT_fields_at_Landlab_nodes_dict):
+        """
+        Determine horizontal velocity from ASPECT variables. In 3D, the horizontal velocity is obtained by directly projecting the 
+        x and y velocity from ASPECT to the links of the Landlab mesh. In 2D, the horizontal velocity is obtained by projecting the 
+        x velocity from ASPECT to the links of the Landlab mesh and setting the y velocity to zero.
+
+        For a 2D ASPECT model, the coupling currently only supports structured Landlab grids. The velocity from ASPECT is projected
+        across the Landlab grid such that the values from ASPECT are fixed along a given x-value on the Landlab grid.
+
+        Parameters:
+        - ASPECT_dim: the dimension of the ASPECT model (2 or 3).
+        - ASPECT_fields_at_Landlab_nodes_dict: a dictionary mapping ASPECT variables to values at each node on the Landlab mesh.
+        """
+        x_velocity = ASPECT_fields_at_Landlab_nodes_dict["x velocity"]
 
         if ASPECT_dim == 2:
             projected_x_velocity = np.zeros(self.model_grid.number_of_nodes)
@@ -179,10 +201,10 @@ class LandLabTemplate:
             y_vel_at_links = self.model_grid.map_mean_of_link_nodes_to_link(np.zeros(self.model_grid.number_of_nodes)) # y velocity is zero since the ASPECT model is 2D.
 
         elif ASPECT_dim == 3:
-            y_velocity = dict_variable_name_to_value_in_nodes["y velocity"]
+            y_velocity = ASPECT_fields_at_Landlab_nodes_dict["y velocity"]
 
             x_vel_at_links = self.model_grid.map_mean_of_link_nodes_to_link(x_velocity)
-            y_vel_at_links = self.model_grid.map_mean_of_link_nodes_to_link(y_velocity) # y velocity is zero since the ASPECT model is 2D.
+            y_vel_at_links = self.model_grid.map_mean_of_link_nodes_to_link(y_velocity)
 
         self.horizontal_velocity[self.model_grid.horizontal_links] = x_vel_at_links[self.model_grid.horizontal_links]
         self.horizontal_velocity[self.model_grid.vertical_links]   = y_vel_at_links[self.model_grid.vertical_links]
@@ -190,6 +212,19 @@ class LandLabTemplate:
         return self.horizontal_velocity
 
     def dimensional_deposition_erosion(self, ASPECT_dim, deposition_erosion):
+        """
+        Calculate the change in the topography in a way that is consistent with the dimension expected by the ASPECT model.
+        In 3D, this function returns the change in topography at each node. In 2D, this function averages the change in 
+        topography across the y-direction and returns the change in topography along y=0, where the ASPECT surface is 
+        expected to be located.
+
+        For a 2D ASPECT model, the coupling currently only supports structured Landlab grids. The topography determined by
+        Landlab needs to be averaged across the x-direction so that it can be sent to ASPECT as a 1D array.
+        
+        Parameters:
+        - ASPECT_dim: the dimension of the ASPECT model (2 or 3).
+        - deposition_erosion: the change in topography at each node on the Landlab mesh
+        """
         if ASPECT_dim == 2:
             deposition_erosion_2d = np.zeros(len(np.unique(self.model_grid.x_of_node)))
             unique_x_values = np.unique(self.model_grid.x_of_node)
@@ -202,11 +237,20 @@ class LandLabTemplate:
             return deposition_erosion
 
     def checkpoint_model_grid(self):
+        """
+        Checkpoint the Landlab model grid by saving it to a file. This function is called when
+        checkpointing the ASPECT model.
+        """
+
         filename = "./landlab_model_grid_checkpoint.grid"
         save_grid(self.model_grid, filename, clobber=True)
         pass
 
     def load_model_grid(self):
+        """
+        Load the Landlab model grid from a file. This function is called when
+        restarting the ASPECT model from a checkpoint.
+        """
         filename = "./landlab_model_grid_checkpoint.grid"
         self.model_grid = load_grid(filename)
         self.elevation = self.model_grid.at_node["topographic__elevation"]
@@ -214,12 +258,31 @@ class LandLabTemplate:
         pass
 
     def get_initial_topography(self, ASPECT_dim):
+        """
+        Return the initial topography. In 3D, this function returns the initial topography at each node.
+        In 2D, this function returns the initial topography along y=0, where the ASPECT surface is expected to be located.
+
+        Parameters:
+        - ASPECT_dim: the dimension of the ASPECT model (2 or 3).
+        """
         if ASPECT_dim == 2:
             return self.elevation[self.model_grid.y_of_node == 0]
         elif ASPECT_dim == 3:
             return self.elevation
         
     def write_output(self, postprocess_dictionary):
+        """
+        Write output for visualizing the landlab mesh. This calls a function in the Landlab Python module to write output vtk files. 
+        This function is called at the end of each ASPECT timestep after the ASPECT model has been updated and the topography has been evolved.
+        The frequency of Landlab output can be controlled by modifying output_frequency.
+
+        Parameters:
+        - postprocess_dictionary: a dictionary containing information about the current ASPECT timestep, time, and output directory.
+          The dictionary contains the following entries:
+            - "ASPECT timestep": the current ASPECT timestep.
+            - "ASPECT time": the current ASPECT time.
+            - "ASPECT output directory": the directory where ASPECT output is being written.
+        """
         step = postprocess_dictionary["ASPECT timestep"]
         time = postprocess_dictionary["ASPECT time"]
         output_directory = postprocess_dictionary["ASPECT output directory"]
@@ -245,18 +308,49 @@ class LandLabTemplate:
         pass
 
     def get_grid_x(self, ASPECT_dim):
+        """
+        Return the x-coordinates of the grid nodes. In 2D, this function returns the unique x-coordinates.
+        In 3D, this function returns the x-coordinates of all nodes. 
+
+        For a 2D ASPECT model, the coupling currently only supports structured Landlab grids. In the case of
+        a 2D ASPECT model, the coupling assumes that the ASPECT model is located at y=0 on the Landlab mesh,
+        and that the Landlab mesh is structured. Therefore, we only need to extract the unique x-coordinates
+        of the Landlab mesh to interface with the ASPECT model.
+
+        
+        Parameters:
+        - ASPECT_dim: the dimension of the ASPECT model (2 or 3).
+        """
         if ASPECT_dim == 2:
             return np.unique(self.model_grid.x_of_node)
         elif ASPECT_dim == 3:
             return self.model_grid.x_of_node
     
     def get_grid_y(self, ASPECT_dim):
+        """
+        Return the y-coordinates of the grid nodes. In 2D, this function returns an array of zeros equal to 
+        the number of unique x-coordinates. In 3D, this function returns the y-coordinates of all nodes.
+
+        For a 2D ASPECT model, the coupling currently only supports structured Landlab grids. In the case of
+        a 2D ASPECT model, the coupling assumes that the ASPECT model is located at y=0 on the Landlab mesh,
+        and that the Landlab mesh is structured. Therefore, we need to send ASPECT an array of zeros that
+        match the length of the number of unique x-coordinates.
+        
+        Parameters:
+        - ASPECT_dim: the dimension of the ASPECT model (2 or 3).
+        """
         if ASPECT_dim == 2:
-            return np.unique(self.model_grid.y_of_node)
+            return np.zeros(np.unique(self.model_grid.x_of_node).size)
         elif ASPECT_dim == 3:
             return self.model_grid.y_of_node
         
     def get_grid_z(self, ASPECT_dim):
+        """
+        Return the z-coordinates of the grid nodes. This function is only applicable for 3D spherical ASPECT models.
+
+        Parameters:
+        - ASPECT_dim: the dimension of the ASPECT model (2 or 3).
+        """
         if ASPECT_dim == 3:
             return self.model_grid.z_of_node
         else:

--- a/contrib/python/scripts/landlab_template.py
+++ b/contrib/python/scripts/landlab_template.py
@@ -1,0 +1,299 @@
+"""
+Template class used for creating a LandLab script that is then used in the ASPECT-Landlab 
+coupling. This can be imported and the functions can be modified to tailor the needs of the 
+user for productions models or simple tests. 
+"""
+
+from mpi4py import MPI
+import inspect
+import json
+import os
+import numpy as np
+import landlab
+from landlab.io.native_landlab import save_grid, load_grid
+from landlab.io.legacy_vtk import write_legacy_vtk
+from landlab.components import AdvectionSolverTVD
+
+
+class LandLabTemplate:
+    """Template class for LandLab scripts used in ASPECT-Landlab coupling."""
+
+    # Functions that actually get called within ASPECT. These functions are checked to ensure
+    # that the signatures of these function are not modified when instantiating this class.
+    _signature_checked_methods = (
+        "initialize",
+        "finalize",
+        "set_mesh_information",
+        "initialize_landlab_components",
+        "update_until",
+        "checkpoint_model_grid",
+        "load_model_grid",
+        "get_initial_topography",
+        "write_output",
+        "get_grid_x",
+        "get_grid_y",
+        "get_grid_z",
+    )
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        for method_name in LandLabTemplate._signature_checked_methods:
+            # Only validate methods that the subclass overrides directly.
+            if method_name not in cls.__dict__:
+                continue
+
+            base_method = getattr(LandLabTemplate, method_name)
+            sub_method = cls.__dict__[method_name]
+
+            base_signature = inspect.signature(base_method)
+            sub_signature = inspect.signature(sub_method)
+
+            if sub_signature != base_signature:
+                raise TypeError(
+                    f"Invalid override for '{method_name}' in class "
+                    f"'{cls.__name__}': expected signature {base_signature}, "
+                    f"got {sub_signature}."
+                )
+
+    def __init__(self):
+        self.current_time = 0.0
+        self.comm = None
+
+        self.model_grid = None
+        self.elevation  = None
+
+        self.horizontal_velocity         = None
+        self.horizontal_surface_advector = None
+
+
+        self.s2yr = 60 * 60 * 24 * 365.25
+        self.timestep = 0
+        self.vtks = []
+
+    def initialize(self, comm_handle):
+        """Called once by ASPECT at startup."""
+        if comm_handle is not None:
+            self.comm = MPI.Comm.f2py(comm_handle)
+            rank = self.comm.Get_rank()
+            size = self.comm.Get_size()
+            print(f"Python: Hello from Rank {rank} of {size}")
+
+            globalsum = self.comm.allreduce(1, op=MPI.SUM)
+            if self.comm.rank == 0:
+                print(f"\tPython: testing communication; sum {globalsum}")
+        else:
+            print("Python: running sequentially!")
+
+    def finalize(self):
+        """Currently unused."""
+        pass
+
+    # ---------------------------------------------------------------------------
+    # The following functions will need to be modified based on the needs of the user:
+    # - set_mesh_information: create the model grid and initialize the elevation field.
+    #   Here the user can define the geometry and resolution of the landlab mesh.
+    #
+    # - initialize_landlab_components: initialize any LandLab components. Here the user
+    #   chooses which Landlab components will influence the evolution of the topograhy, and
+    #   initializes them with the necessary parameters.
+    #
+    # - update_until: advance the LandLab model through time based on the ASPECT timestep.
+    #   Here the user needs to define how the Landlab components influence the evolution of
+    #   the topography, as well as how fields from ASPECT (composition, temperature etc.,)
+    #   influence the Landlab model.
+    # ---------------------------------------------------------------------------
+    def set_mesh_information(self, grid_dictionary):
+        """
+        Create the Landlab model grid, initialize the elevation field, and any other grid fields needed for
+        the Landlab model. Call the function initialize_landlab_components() at the end of this function to 
+        initialize the Landlab components after the grid and fields have been created.
+        ** Derived classes must override this function in custom scripts. **
+        """
+        raise NotImplementedError("LandLabTemplate.set_mesh_information() must be overridden in your custom script." \
+                                  "See the doc string in the template file for information on how to write this function.")
+
+
+
+    def initialize_landlab_components(self):
+        """
+        Initialize the Landlab components that will be used to evolve the topography over time.
+        ** Derived classes must override this function in custom scripts. **
+        """
+        raise NotImplementedError("LandLabTemplate.initialize_landlab_components() must be overridden in your custom script." \
+                                  "See the doc string in the template file for information on how to write this function.")
+
+
+
+    def update_until(self, end_time, ASPECT_dim, ASPECT_fields_at_Landlab_nodes_dict):
+        """
+        Run the Landlab model for the duration of the ASPECT timestep and return the change in topography at each node.
+        This function is where the LandLab components will be called. The change in topography is used to determine the 
+        surface velocity of the ASPECT mesh.
+        ** Derived classes must override this function in custom scripts. **
+
+        Parameters:
+        - end_time: the time to advance the Landlab model to.
+
+        - ASPECT_dim: the dimensionality of the ASPECT model (2 or 3).
+
+        - ASPECT_fields_at_Landlab_nodes_dict: a dictionary mapping ASPECT variable names to their values at each node on
+                                               the LandLab mesh. This dictionary will include entries for "x velocity" and
+                                               "y velocity" (and "z velocity" for 3D models), as well as the compositional
+                                                fields, and the pressure and temperature.
+        """
+
+        raise NotImplementedError("LandLabTemplate.update_until() must be overridden in your custom script." \
+                                  "See the doc string in the template file for information on how to write this function.")
+
+
+
+    # ---------------------------------------------------------------------------
+    # The rest of these functions likely will not require any modification.
+    # ---------------------------------------------------------------------------
+    def determine_uplift_velocity(self, ASPECT_dim, dict_variable_name_to_value_in_nodes):
+        """Determine uplift velocity from ASPECT variables."""
+        if ASPECT_dim == 2:
+            slice_y_velocity = dict_variable_name_to_value_in_nodes["y velocity"]
+
+            vertical_velocity = np.zeros(self.model_grid.number_of_nodes)
+            unique_x_values = np.unique(self.model_grid.x_of_node)
+            for x in unique_x_values:
+                vertical_velocity[self.model_grid.x_of_node == x] = slice_y_velocity[unique_x_values == x]
+        elif ASPECT_dim == 3:
+            vertical_velocity = dict_variable_name_to_value_in_nodes["z velocity"]
+
+        return vertical_velocity
+    
+    def determine_horizontal_velocity(self, ASPECT_dim, dict_variable_name_to_value_in_nodes):
+        """Determine horizontal velocity from ASPECT variables."""
+        x_velocity = dict_variable_name_to_value_in_nodes["x velocity"]
+
+        if ASPECT_dim == 2:
+            projected_x_velocity = np.zeros(self.model_grid.number_of_nodes)
+            unique_x_values   = np.unique(self.model_grid.x_of_node)
+            for x in unique_x_values:
+                projected_x_velocity[self.model_grid.x_of_node == x] = x_velocity[unique_x_values == x]
+            
+            x_vel_at_links = self.model_grid.map_mean_of_link_nodes_to_link(projected_x_velocity)
+            y_vel_at_links = self.model_grid.map_mean_of_link_nodes_to_link(np.zeros(self.model_grid.number_of_nodes)) # y velocity is zero since the ASPECT model is 2D.
+
+        elif ASPECT_dim == 3:
+            y_velocity = dict_variable_name_to_value_in_nodes["y velocity"]
+
+            x_vel_at_links = self.model_grid.map_mean_of_link_nodes_to_link(x_velocity)
+            y_vel_at_links = self.model_grid.map_mean_of_link_nodes_to_link(y_velocity) # y velocity is zero since the ASPECT model is 2D.
+
+        self.horizontal_velocity[self.model_grid.horizontal_links] = x_vel_at_links[self.model_grid.horizontal_links]
+        self.horizontal_velocity[self.model_grid.vertical_links]   = y_vel_at_links[self.model_grid.vertical_links]
+
+        return self.horizontal_velocity
+
+    def dimensional_deposition_erosion(self, ASPECT_dim, deposition_erosion):
+        if ASPECT_dim == 2:
+            deposition_erosion_2d = np.zeros(len(np.unique(self.model_grid.x_of_node)))
+            unique_x_values = np.unique(self.model_grid.x_of_node)
+
+            for x in unique_x_values:
+                deposition_erosion_2d[unique_x_values == x] = np.average(deposition_erosion[self.model_grid.x_of_node == x])
+            return deposition_erosion_2d
+        
+        elif ASPECT_dim == 3:
+            return deposition_erosion
+
+    def checkpoint_model_grid(self):
+        filename = "./landlab_model_grid_checkpoint.grid"
+        save_grid(self.model_grid, filename, clobber=True)
+        pass
+
+    def load_model_grid(self):
+        filename = "./landlab_model_grid_checkpoint.grid"
+        self.model_grid = load_grid(filename)
+        self.elevation = self.model_grid.at_node["topographic__elevation"]
+        self.initialize_landlab_components(None)
+        pass
+
+    def get_initial_topography(self, ASPECT_dim):
+        if ASPECT_dim == 2:
+            return self.elevation[self.model_grid.y_of_node == 0]
+        elif ASPECT_dim == 3:
+            return self.elevation
+        
+    def write_output(self, postprocess_dictionary):
+        step = postprocess_dictionary["ASPECT timestep"]
+        time = postprocess_dictionary["ASPECT time"]
+        output_directory = postprocess_dictionary["ASPECT output directory"]
+
+        output_frequency = 10
+        if step % output_frequency != 0:
+            return
+
+        filename = f"{output_directory}/landlab_{str(step).zfill(3)}.vtk"
+        write_legacy_vtk(path=filename, grid=self.model_grid, clobber=True)
+        self.vtks.append((time, filename))
+
+        with open(f"{output_directory}/landlab.vtk.series", "w") as f:
+            series = {
+                "file-series-version": "1.0",
+                "files": [
+                    {"name": os.path.basename(vtk_name), "time": vtk_time}
+                    for vtk_time, vtk_name in self.vtks
+                ],
+            }
+            json.dump(series, f, indent=2)
+
+        pass
+
+    def get_grid_x(self, ASPECT_dim):
+        if ASPECT_dim == 2:
+            return np.unique(self.model_grid.x_of_node)
+        elif ASPECT_dim == 3:
+            return self.model_grid.x_of_node
+    
+    def get_grid_y(self, ASPECT_dim):
+        if ASPECT_dim == 2:
+            return np.unique(self.model_grid.y_of_node)
+        elif ASPECT_dim == 3:
+            return self.model_grid.y_of_node
+        
+    def get_grid_z(self, ASPECT_dim):
+        if ASPECT_dim == 3:
+            return self.model_grid.z_of_node
+        else:
+            raise ValueError("get_grid_z is only applicable for 3D ASPECT models.")
+
+    @staticmethod
+    def export_aspect_callbacks(model, namespace):
+        """
+        Export the functions of the derived class as module-level functions in the provided namespace. 
+        By using this function, the user can simply define a class that inherits from LandLabTemplate, 
+        override any desired functions, and then call this export function to make the functions available 
+        to ASPECT without needing to always write boilerplate functions.
+
+        Parameters:
+        - model: an instance of a class that inherits from LandLabTemplate.
+        - namespace: the namespace to which the functions should be added. This is typically done by
+                     passing in globals() from the script that defines the derived class.
+
+        Example usage:
+        model = MyAspectLandlabModel()
+        model.export_aspect_callbacks(model, globals())
+        """
+
+        # Name of all the functions that ASPECT requires.
+        callback_names = (
+            "initialize",
+            "finalize",
+            "update_until",
+            "set_mesh_information",
+            "get_grid_x",
+            "get_grid_y",
+            "get_initial_topography",
+            "checkpoint_model_grid",
+            "load_model_grid",
+            "write_output",
+        )
+
+        namespace["model"] = model
+        for name in callback_names:
+            namespace[name] = getattr(model, name)

--- a/cookbooks/landlab/test-template/TEST-TEMPLATE.prm
+++ b/cookbooks/landlab/test-template/TEST-TEMPLATE.prm
@@ -1,0 +1,181 @@
+# This cookbook is used as a test to ensure that FastScape is properly working with ASPECT.
+# It consists of a 2.5 km high central mountain block that is eroded through the use of
+# hillslope diffusion and the Stream Power Law. Within ASPECT, the model is based off
+# convection-box-3d. However, it is set up in a way that nothing happens in the geodynamic model.
+
+# At the top, we define the number of space dimensions we would like to
+# work in:
+set Dimension                              = 2
+set Use years instead of seconds           = true
+set End time                               = 10e6
+set Maximum time step                      = 10000
+set Output directory                       = output-template
+set Pressure normalization                 = no
+set Surface pressure                       = 0
+set Resume computation                     = false
+set Nonlinear solver scheme                = iterated Advection and Stokes
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block AMG
+  end
+end
+
+subsection Discretization
+  set Composition polynomial degree           = 2
+  set Stokes velocity polynomial degree       = 2
+  set Temperature polynomial degree           = 2
+  set Use discontinuous composition discretization = true
+end
+
+# A box that has an initial 60x60 km mountain block that is 2.5 km above the initial model surface.
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 100e3
+    set Y extent = 25e3
+
+    set X repetitions = 4
+    set Y repetitions = 1
+  end
+end
+
+# We do not consider temperature in this setup
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = bottom, top
+  set List of model names = initial temperature
+end
+
+# X Set all boundaries except the top to freeslip.
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = bottom:function, left:function, right:function #, front:function, back:function
+  subsection Function
+    set Coordinate system   = cartesian
+    set Variable names      = x,y,t
+    set Function constants  = uplift_rate=0, cm=0.0
+    set Function expression = 0; uplift_rate * cm
+  end
+end
+
+# subsection Boundary traction model
+#   set Prescribed traction boundary indicators = right: initial lithostatic pressure, left: initial lithostatic pressure
+#   subsection Initial lithostatic pressure
+#     set Number of integration points = 10000
+#     set Representative point         = 0.0, 0.0
+#   end
+# end
+
+# Here we setup the top boundary with fastscape.
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: Landlab
+  set Additional tangential mesh velocity boundary indicators = left, right
+
+  subsection Landlab
+    set MPI ranks for Landlab = 1
+    # set Script name           = 2D-rectangular_topography
+    set Script name           = import-template
+    set Script argument       =
+    set Script path           =
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 1e-100
+  end
+end
+
+# Dimensionless
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 1
+    set Thermal expansion coefficient = 1
+    set Viscosity                     = 1
+  end
+end
+
+# We also have to specify that we want to use the Boussinesq
+# approximation (assuming the density in the temperature
+# equation to be constant, and incompressibility).
+subsection Formulation
+  set Formulation = Boussinesq approximation
+end
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Compositional field methods =  field, field
+  set Types of fields =  chemical composition,  chemical composition
+  set Names of fields = strong, weak
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Coordinate system   =  cartesian
+    set Variable names      =  x,y,t
+    set Function expression = if(x>=50e3, 0.0, 1.0); if(x<=50e3, 0.0, 1.0)
+  end
+end
+
+subsection Boundary composition model
+  set Fixed composition boundary indicators         = bottom, top
+  set List of model names                           =  initial composition
+  set Allow fixed composition on outflow boundaries = true
+end
+
+
+# We set a maximum surface refinement level of 4 using the max/minimum refinement level.
+# This will make it so that the ASPECT surface refinement is the same as what we set
+# for our maximum surface refinement level for FastScape.
+subsection Mesh refinement
+  set Initial global refinement                = 3
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+#   set Strategy                                 = minimum refinement function, maximum refinement function
+
+#   subsection Maximum refinement function
+#     set Coordinate system   = cartesian
+#     set Variable names      = x,y,z
+#     set Function expression = if(y>=21000, 4, 2)
+#   end
+
+#   subsection Minimum refinement function
+#     set Coordinate system   = cartesian
+#     set Variable names      = x,y,z
+#     set Function expression = if(y>=21000, 4, 2)
+#   end
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, topography, velocity statistics, composition statistics
+
+  subsection Topography
+    set Output to file = true
+    set Time between text output = 50e3
+  end
+
+  subsection Visualization
+    set Time between graphical output = 50e3
+    set Output mesh velocity = true
+    set Output mesh displacement = true
+    set Output undeformed mesh = false
+    set Interpolate output = false
+  end
+
+end

--- a/cookbooks/landlab/test-template/import-template.py
+++ b/cookbooks/landlab/test-template/import-template.py
@@ -1,0 +1,129 @@
+
+from mpi4py import MPI
+import importlib.util
+import os
+import sys
+import numpy as np
+import landlab
+from landlab.components import LinearDiffuser, AdvectionSolverTVD
+
+# ---------------------------------------------------------------------------
+# Import LandLabTemplate base class, which is located in contrib/python/scripts/.
+# ---------------------------------------------------------------------------
+from landlab_template import LandLabTemplate
+
+
+# ---------------------------------------------------------------------------
+# Custom model — override only the methods you want to change.
+# ---------------------------------------------------------------------------
+class MyAspectLandlabModel(LandLabTemplate):
+
+    def update_until(self, end_time, ASPECT_dim, ASPECT_fields_at_Landlab_nodes_dict):
+        dt = end_time - self.current_time
+        self.timestep += 1
+
+        deposition_erosion = np.zeros(self.model_grid.number_of_nodes)
+
+        vertical_velocity                = self.determine_uplift_velocity(ASPECT_dim, ASPECT_fields_at_Landlab_nodes_dict)
+        self.horizontal_velocity         = self.determine_horizontal_velocity(ASPECT_dim, ASPECT_fields_at_Landlab_nodes_dict)
+        self.horizontal_surface_advector = AdvectionSolverTVD(self.model_grid, fields_to_advect=self.elevation)
+
+        # Extract compositions along the ASPECT surface.
+        slice_weak_composition   = ASPECT_fields_at_Landlab_nodes_dict["weak"]
+        slice_strong_composition = ASPECT_fields_at_Landlab_nodes_dict["strong"]
+
+        # Project composition values from y=0 to all Landlab nodes.
+        strong_composition = np.zeros(self.model_grid.number_of_nodes)
+        weak_composition   = np.zeros(self.model_grid.number_of_nodes)
+
+        unique_x_values = np.unique(self.model_grid.x_of_node)
+        for x in unique_x_values:
+            strong_composition[self.model_grid.x_of_node == x] = slice_strong_composition[unique_x_values == x]
+            weak_composition[self.model_grid.x_of_node == x]   = slice_weak_composition[unique_x_values == x]
+
+        # Modify diffusivity based on composition.
+        self.Diffusivity[strong_composition >= 0.5] = 1e-10 / self.s2yr
+        self.Diffusivity[weak_composition >= 0.5]   = 10 / self.s2yr
+
+        if dt > 0:
+            n_substeps = 10
+            sub_dt = dt / n_substeps
+            for _ in range(n_substeps):
+                elevation_before = self.elevation.copy()
+                self.linear_diffuser.run_one_step(sub_dt)
+                self.elevation += vertical_velocity * sub_dt
+                deposition_erosion += self.elevation - elevation_before
+
+        self.current_time = end_time
+        print("Max elevation:", np.max(self.elevation), "Min elevation:", np.min(self.elevation))
+
+        # Return the change in topography along y=0, where the ASPECT mesh is located.
+        dimensional_deposition_erosion = self.dimensional_deposition_erosion(ASPECT_dim, deposition_erosion)
+        return dimensional_deposition_erosion
+
+    def set_mesh_information(self, grid_dictionary):
+        if self.model_grid is not None:
+            return
+
+        print("* Creating RasterModelGrid ...")
+        x_extent = 100e3
+        y_extent = 100e3
+        spacing  = 500.0
+
+        nrows = int(y_extent / spacing) + 1
+        ncols = int(x_extent / spacing) + 1
+
+        self.model_grid = landlab.RasterModelGrid(
+            (nrows, ncols),
+            xy_spacing=(spacing, spacing),
+            xy_of_lower_left=(0, -y_extent / 2),
+        )
+
+        print("* Creating topographic elevation ...")
+        self.elevation = self.model_grid.add_zeros("topographic__elevation", at="node")
+        self.horizontal_velocity = self.model_grid.add_zeros("advection__velocity", at="link")
+
+        # Triangular mountain in the centre of the domain.
+        topo_height  = 20e3
+        left_x_arr   = np.array([25e3, 50e3])
+        left_y_arr   = np.array([0.0, topo_height])
+        right_x_arr  = np.array([50e3, 75e3])
+        right_y_arr  = np.array([topo_height, 0.0])
+
+        left_m,  left_b  = np.polyfit(left_x_arr,  left_y_arr,  deg=1)
+        right_m, right_b = np.polyfit(right_x_arr, right_y_arr, deg=1)
+
+        self.elevation[self.model_grid.x_of_node <= 50e3] = (
+            left_m * self.model_grid.x_of_node[self.model_grid.x_of_node <= 50e3] + left_b
+        )
+        self.elevation[self.model_grid.x_of_node > 50e3] = (
+            right_m * self.model_grid.x_of_node[self.model_grid.x_of_node > 50e3] + right_b
+        )
+        self.elevation[self.model_grid.x_of_node < np.min(left_x_arr)]  = 0.0
+        self.elevation[self.model_grid.x_of_node > np.max(right_x_arr)] = 0.0
+
+        self.model_grid.set_closed_boundaries_at_grid_edges(
+            right_is_closed=True,
+            left_is_closed=True,
+            top_is_closed=True,
+            bottom_is_closed=True,
+        )
+        print("\tnumber of nodes:", self.model_grid.number_of_nodes)
+
+        self.initialize_landlab_components()
+        print("* Done")
+        return self.model_grid
+
+    def initialize_landlab_components(self):
+        D = 1e-10 / self.s2yr
+        self.Diffusivity = self.model_grid.add_zeros("linear_diffusivity", at="node")
+        self.Diffusivity += D
+        self.linear_diffuser = LinearDiffuser(self.model_grid, linear_diffusivity=self.Diffusivity)
+
+
+# ---------------------------------------------------------------------------
+# Module-level instance — ASPECT calls these functions by name.
+# ---------------------------------------------------------------------------
+model = MyAspectLandlabModel()
+model.export_aspect_callbacks(model, globals())
+

--- a/source/mesh_deformation/landlab.cc
+++ b/source/mesh_deformation/landlab.cc
@@ -108,6 +108,7 @@ namespace aspect
           PyRun_SimpleString("import sys");
           PyRun_SimpleString("sys.path.append(\"" ASPECT_SOURCE_DIR "/tests\")");
           PyRun_SimpleString("sys.path.append(\".\")");
+          PyRun_SimpleString("sys.path.append(\"" ASPECT_SOURCE_DIR "/contrib/python/scripts\")");
 
           // avoid floating point exceptions in Landlab Python code:
 #ifdef ASPECT_USE_FP_EXCEPTIONS
@@ -177,7 +178,7 @@ namespace aspect
 
           {
             // get grid:
-            PyObject *pArgs = PyTuple_Pack(1, PyLong_FromLong(-1L));
+            PyObject *pArgs = PyTuple_Pack(1, PyLong_FromLong(dim));
             PyObject *pgrid_x = call_python_function(pModule, "get_grid_x", pArgs);
 
             PyObject *pgrid_y = nullptr;
@@ -269,7 +270,7 @@ namespace aspect
             }
 
           // Call update_until()
-          PyObject *pArgs = PyTuple_Pack(2, PyFloat_FromDouble(this->get_time()), pDict);
+          PyObject *pArgs = PyTuple_Pack(3, PyFloat_FromDouble(this->get_time()), PyLong_FromLong(dim), pDict);
           PyObject *pValue = call_python_function(pModule, "update_until", pArgs);
           Py_DECREF(pDict);
           Py_DECREF(pArgs);
@@ -344,13 +345,7 @@ namespace aspect
       std::vector<Tensor<1,dim>> initial_deformation(this->evaluation_points.size(), Tensor<1,dim>());
       if (this_rank_runs_landlab)
         {
-          PyObject *pDict = PyDict_New();
-          PyDict_SetItemString(pDict, "ASPECT Dimension", PyLong_FromLong(dim));
-
-          PyObject *pArgs = PyTuple_Pack(1,
-                                         pDict
-                                        );
-          Py_DECREF(pDict);
+          PyObject *pArgs = PyTuple_Pack(1, PyLong_FromLong(dim));
           PyObject *pValue = call_python_function(pModule, "get_initial_topography", pArgs);
           Py_DECREF(pArgs);
           ArrayView<double> data = PythonHelper::numpy_to_array_view(pValue);

--- a/tests/mesh_deformation_external_landlab_01.py
+++ b/tests/mesh_deformation_external_landlab_01.py
@@ -38,7 +38,7 @@ def finalize():
 # dict_variable_name_to_value_in_nodes is a dictionary mapping variables
 # (x velocity, y velocity, temperature, etc.) to an array of values in each
 # node.
-def update_until(end_time, dict_variable_name_to_value_in_nodes):
+def update_until(end_time, ASPECT_dim, dict_variable_name_to_value_in_nodes):
     global current_time
     dt = end_time - current_time
     

--- a/tests/mesh_deformation_external_landlab_02.py
+++ b/tests/mesh_deformation_external_landlab_02.py
@@ -48,7 +48,7 @@ def finalize():
 # dict_variable_name_to_value_in_nodes is a dictionary mapping variables
 # (x velocity, y velocity, temperature, etc.) to an array of values in each
 # node.
-def update_until(end_time, dict_variable_name_to_value_in_nodes):
+def update_until(end_time, ASPECT_dim, dict_variable_name_to_value_in_nodes):
 
     print(f"update_until: end_time = {end_time}")
    


### PR DESCRIPTION
This PR adds an initial implementation of a python class for helping create new landlab scripts. The class is meant to be imported into other python files and act primarily as a foundation for creating tests for the coupling. There are a few things that this template currently does that are advantageous:

1. All of the python functions which are explicitly called by ASPECT are defined, and the signature of the functions are checked when instantiating the class elsewhere. This means that if we have a proven test suite and then in a PR we modify one of the class functions (to include an additional argument for example), then tests which override this function will throw an error.
2. Aside from the 3 functions which will always need to be modified (`set_mesh_information`, `initialize_landlab_components`, and `update_until`), all of the other functions can be called without needing to be defined within the new python file, greatly reducing duplicated code.
3. Generalizes most of the python functions (and adds a few helper functions) so that they take the ASPECT dimension as an argument, and then correctly handle the 2D/3D cases. Therefore, less work has to be done by the user to account for T-models vs volume models.

One thing that I wasn't able to properly figure out is how to generalize the importing of this class into other python files. In the example included in this PR, I had coded in the path to $ASPECT_SOURCE_DIR on my local machine because I couldn't figure out a way to cleanly determine where `$ASPECT_SOURCE_DIR/contrib/python/scripts` would be located on the machine running ASPECT. Since ASPECT is the one that ultimately "calls" the python file though, I'm wondering if there is a way for ASPECT to send the python file the path before running it.