### PR TITLE
Add Assert for Normalizing Pressure

### DIFF
--- a/source/mesh_deformation/landlab.cc
+++ b/source/mesh_deformation/landlab.cc
@@ -85,6 +85,11 @@ namespace aspect
     void
     Landlab<dim>::initialize ()
     {
+      // Pressure normalization doesn't really make sense with a free surface, and if we do
+      // use it, we can run into problems with geometry_model->depth().
+      AssertThrow ( this->get_parameters().pressure_normalization == "no",
+                    ExcMessage("The Landlab mesh deformation model can only be used with no pressure normalization") );
+
       // Determine whether we are in a spherical geometry or not, which affects how we interpret the coordinates of the evaluation points.
       if (Plugins::plugin_type_matches<GeometryModel::Chunk<dim>>(this->get_geometry_model()) ||
           Plugins::plugin_type_matches<GeometryModel::SphericalShell<dim>>(this->get_geometry_model()) ||

--- a/tests/mesh_deformation_external_landlab_01.prm
+++ b/tests/mesh_deformation_external_landlab_01.prm
@@ -9,7 +9,7 @@ set Use years instead of seconds           = false
 set End time                               = 0.004
 set Maximum time step                      = 0.0005
 set Nonlinear solver scheme = no Advection, no Stokes
-set Pressure normalization                 = surface
+set Pressure normalization                 = no
 set Surface pressure                       = 0
 
 subsection Geometry model

--- a/tests/mesh_deformation_external_landlab_02.prm
+++ b/tests/mesh_deformation_external_landlab_02.prm
@@ -10,7 +10,7 @@ set Use years instead of seconds           = false
 set End time                               = 0.001
 set Maximum time step                      = 0.0005
 set Nonlinear solver scheme = no Advection, no Stokes
-set Pressure normalization                 = surface
+set Pressure normalization                 = no
 set Surface pressure                       = 0
 
 subsection Geometry model


### PR DESCRIPTION
This came up when I was doing some testing comparing landlab output with just the regular free surface in ASPECT. Since Landlab is essentially just a free surface with other processes, I think it makes sense to enforce this here as well.