### PR TITLE
Add aspect landlab diffusion benchmark

### DIFF
--- a/benchmarks/diffusion_of_hill/1_shine_zero_flux_landlab_import-template.py
+++ b/benchmarks/diffusion_of_hill/1_shine_zero_flux_landlab_import-template.py
@@ -1,0 +1,148 @@
+from mpi4py import MPI
+import importlib.util
+import os
+import sys
+
+import numpy as np
+np.set_printoptions(suppress=False, precision=12)
+import landlab
+from landlab.components import LinearDiffuser, AdvectionSolverTVD
+
+import json
+from landlab.io.legacy_vtk import write_legacy_vtk
+
+
+from landlab_template import LandLabTemplate
+
+
+class MyAspectLandlabModel(LandLabTemplate):
+
+
+
+    def update_until(self, end_time, ASPECT_dim, ASPECT_fields_at_Landlab_nodes_dict):
+
+        dt = end_time - self.current_time
+        self.timestep += 1
+
+        deposition_erosion = np.zeros(self.model_grid.number_of_nodes)
+
+
+        # =====================================================
+        # TIME STEPPING
+        # =====================================================
+        if dt > 0:
+            n_substeps = 10
+            sub_dt = dt / n_substeps
+
+            for _ in range(n_substeps):
+                elevation_before = self.elevation.copy()
+
+                # Diffusion (Landlab physics)
+                self.linear_diffuser.run_one_step(sub_dt)
+
+                
+                deposition_erosion += self.elevation - elevation_before
+
+        self.current_time = end_time
+
+
+        print("Max elevation:", np.max(self.elevation),
+            "Min elevation:", np.min(self.elevation))
+
+
+
+        dimensional_deposition_erosion = self.dimensional_deposition_erosion(
+            ASPECT_dim,
+            deposition_erosion
+        )
+
+        return dimensional_deposition_erosion
+    
+
+    def set_mesh_information(self, grid_dictionary):
+        print("grid_dictionary =", grid_dictionary)
+
+        if grid_dictionary is not None:
+            print(grid_dictionary.keys())
+
+        if self.model_grid is not None:
+            return
+        
+        if self.model_grid is not None:
+            return
+
+        print("* Creating RasterModelGrid ...")
+
+        # =====================================================
+        # FIXED DOMAIN (MATCH ASPECT 3D TOP SURFACE)
+        # =====================================================
+        x_extent = 1
+        y_extent = 1
+        spacing  = 0.015625
+
+        
+
+        nrows = int(y_extent / spacing) + 3
+        ncols = int(x_extent / spacing) + 3
+
+        self.model_grid = landlab.RasterModelGrid(
+            (nrows, ncols),
+            xy_spacing=(spacing, spacing),
+            xy_of_lower_left=(-spacing, -spacing),
+        )
+
+        print("* Creating topographic elevation ...")
+
+
+
+        A = 0.075
+        L = 1.0
+
+        z = A * np.sin(np.pi * self.model_grid.node_x / L)
+
+        self.elevation = self.model_grid.add_field(
+            "topographic__elevation",
+            z,
+            at="node"
+        )
+
+        self.elevation = z
+
+
+       
+        self.model_grid.set_closed_boundaries_at_grid_edges(
+            right_is_closed=True,
+            left_is_closed=True,
+            top_is_closed=True,
+            bottom_is_closed=True,
+        )
+
+        
+
+        print("\tnumber of nodes:", self.model_grid.number_of_nodes)
+
+        self.initialize_landlab_components()
+        print("* Done")
+
+        return self.model_grid
+
+    def initialize_landlab_components(self):
+     
+        D = 0.25 # m2/second
+        # D = 0.25 /self.s2yr # 7*1e-9 m2/second
+
+        self.Diffusivity = self.model_grid.add_zeros(
+            "linear_diffusivity",
+            at="node"
+        )
+
+        self.Diffusivity += D
+
+        self.linear_diffuser = LinearDiffuser(
+            self.model_grid,
+            linear_diffusivity=self.Diffusivity
+        )
+
+
+model = MyAspectLandlabModel()
+model.export_aspect_callbacks(model, globals())

--- a/benchmarks/diffusion_of_hill/1_sine_zero_flux_landlab.prm
+++ b/benchmarks/diffusion_of_hill/1_sine_zero_flux_landlab.prm
@@ -1,0 +1,119 @@
+set Additional shared libraries            = libanalytical_topography.so
+set Dimension                              = 2
+set Use years instead of seconds           = false
+set End time                               = 0.1
+set Maximum time step                      = 0.0005
+set Output directory                       = output-1_sine_zero_flux_landlab/
+set Nonlinear solver scheme = no Advection, no Stokes
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+
+# 1x1 box with an initial hill topography
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+    set Y extent = 1
+  end
+
+
+end
+
+# Temperature effects are ignored
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = bottom, top
+  set List of model names = initial temperature
+end
+
+# Free slip on all boundaries
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = left, right, bottom, top
+end
+
+# The mesh will be deformed according to the displacement
+# of the surface nodes due to diffusion of the topography.
+# The mesh is allowed to move vertical along the left and
+# right boundary.
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: Landlab
+  set Additional tangential mesh velocity boundary indicators =
+
+  subsection Landlab
+    set MPI ranks for Landlab = 1
+    set Script name           = 1_shine_zero_flux_landlab_import-template
+    set Script path           = .
+    set Script argument       =
+  end
+end
+
+# Vertical gravity
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 1
+  end
+end
+
+# One material with unity properties
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 1
+    set Thermal expansion coefficient = 1
+    set Viscosity                     = 1
+  end
+end
+
+# We also have to specify that we want to use the Boussinesq
+# approximation (assuming the density in the temperature
+# equation to be constant, and incompressibility).
+subsection Formulation
+  set Formulation = Boussinesq approximation
+end
+
+# We here use a globally refined mesh without
+# adaptive mesh refinement.
+subsection Mesh refinement
+  set Initial global refinement                = 6
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+end
+
+# We output the computed topography and the analytical topography
+# value to file.
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, visualization, analytical topography,  topography
+
+  subsection Topography
+    set Output to file = true
+    set Analytical solution of example = 1
+    set Diffusivity = 0.25
+    set Initial sinusoidal topography amplitude = 0.075
+  end
+
+  subsection Visualization
+    set Time between graphical output = 0.025
+    set Output mesh velocity = true
+    set Interpolate output = false
+  end
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Linear solver tolerance                         = 1e-7
+  end
+end

--- a/benchmarks/diffusion_of_hill/plotter_Landlab_ASPECT_benchmark_diffusion_hill.py
+++ b/benchmarks/diffusion_of_hill/plotter_Landlab_ASPECT_benchmark_diffusion_hill.py
@@ -1,0 +1,325 @@
+
+
+"""
+===============================================================================
+Surface Topography Benchmark Plotter
+===============================================================================
+
+This script reproduces the benchmark plotting workflow used for the
+Landlab-ASPECT diffusion hill benchmark.
+
+It generates:
+
+1. Surface topography comparison:
+      - Landlab-ASPECT solution
+      - Analytical solution
+
+2. Percentage error plot
+
+Input files expected:
+
+    topography.00060
+    topography.00120
+    topography.00180
+
+Each file must contain at least four columns:
+
+    column 0 : x coordinate
+    column 2 : ASPECT topography
+    column 3 : analytical topography
+
+Output:
+
+    result_benchmark_ASPECT/
+        surface_topo_benchmark_ASPECT_<run_folder>.png
+        surface_topo_error_benchmark_ASPECT_<run_folder>.png
+
+===============================================================================
+"""
+
+from pathlib import Path
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+# =============================================================================
+# USER SETTINGS
+# =============================================================================
+
+RUN_FOLDER = "output-1_sine_zero_flux_landlab"
+
+# Plot ranges
+
+X_RANGE = [0.0, 1.0]
+
+Y_RANGE_TOPO = [0.0, 0.1]
+
+Y_RANGE_ERROR = [0.0, 2.0]
+
+
+# =============================================================================
+# INPUT FILES
+# =============================================================================
+
+TIMES = [
+    ("00060", "60", "#1f77b4"),
+    ("00120", "120", "#d62728"),
+    ("00180", "180", "#2ca02c"),
+]
+
+
+# =============================================================================
+# FIGURE STYLE
+# =============================================================================
+
+plt.rcParams.update(
+    {
+        "font.size": 18,
+        "axes.linewidth": 2,
+    }
+)
+
+
+# =============================================================================
+# FUNCTIONS
+# =============================================================================
+
+def load_topography_file(filename):
+    """
+    Read benchmark topography file.
+    """
+
+    data = np.loadtxt(filename)
+
+    x = data[:, 0]
+    aspect = data[:, 2]
+    analytical = data[:, 3]
+
+    return x, aspect, analytical
+
+
+def compute_mad(aspect, analytical):
+    """
+    Mean Absolute Difference.
+    """
+
+    return np.mean(np.abs(aspect - analytical))
+
+
+def compute_percent_error(aspect, analytical):
+    """
+    Percentage error.
+
+    Protect against divide-by-zero.
+    """
+
+    return np.where(
+        np.abs(analytical) > 1.0e-12,
+        np.abs((analytical - aspect) / analytical) * 100.0,
+        0.0,
+    )
+
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+def main():
+
+    output_dir = Path(RUN_FOLDER)
+
+    result_dir = output_dir / "result_benchmark_ASPECT"
+
+    result_dir.mkdir(parents=True, exist_ok=True)
+
+    # =========================================================================
+    # TOPOGRAPHY PLOT
+    # =========================================================================
+
+    fig, ax = plt.subplots(figsize=(18, 10))
+
+    mad_values = []
+
+    for step, time_label, color in TIMES:
+
+        file_path = output_dir / f"topography.{step}"
+
+        if not file_path.exists():
+            print(f"WARNING: Missing file: {file_path}")
+            continue
+
+        x, aspect, analytical = load_topography_file(file_path)
+
+        mad = compute_mad(aspect, analytical)
+
+        mad_values.append((time_label, mad, color))
+
+        # ---------------------------------------------------------------------
+        # ASPECT solution
+        # ---------------------------------------------------------------------
+
+        ax.plot(
+            x,
+            aspect,
+            marker="o",
+            markersize=6,
+            linewidth=3,
+            color=color,
+            label=f"ASPECT t={time_label}",
+        )
+
+        # ---------------------------------------------------------------------
+        # Analytical solution
+        # ---------------------------------------------------------------------
+
+        ax.plot(
+            x,
+            analytical,
+            linestyle="--",
+            linewidth=4,
+            color=color,
+            label=f"Analytical t={time_label}",
+        )
+
+    # -------------------------------------------------------------------------
+    # Styling
+    # -------------------------------------------------------------------------
+
+    ax.set_xlim(X_RANGE)
+
+    ax.set_ylim(Y_RANGE_TOPO)
+
+    ax.set_xlabel("X [-]", fontsize=22)
+
+    ax.set_ylabel("Topography [m]", fontsize=22)
+
+    ax.set_title(
+        f"Surface Topography Benchmark\n{RUN_FOLDER}",
+        fontsize=26,
+    )
+
+    ax.grid(True, alpha=0.3)
+
+    ax.legend(
+        loc="upper right",
+        framealpha=1.0,
+        fontsize=16,
+    )
+
+    # -------------------------------------------------------------------------
+    # MAD annotations
+    # -------------------------------------------------------------------------
+
+    ypos = 0.92
+
+    for time_label, mad, color in mad_values:
+
+        ax.text(
+            0.02,
+            ypos,
+            f"MAD t={time_label} = {mad:.3e} m",
+            transform=ax.transAxes,
+            color=color,
+            fontsize=16,
+        )
+
+        ypos -= 0.05
+
+    topo_png = (
+        result_dir
+        / f"surface_topo_benchmark_ASPECT_{RUN_FOLDER}.png"
+    )
+
+    fig.savefig(
+        topo_png,
+        dpi=300,
+        bbox_inches="tight",
+    )
+
+    plt.close(fig)
+
+    # =========================================================================
+    # ERROR PLOT
+    # =========================================================================
+
+    fig, ax = plt.subplots(figsize=(18, 10))
+
+    for step, time_label, color in TIMES:
+
+        file_path = output_dir / f"topography.{step}"
+
+        if not file_path.exists():
+            continue
+
+        x, aspect, analytical = load_topography_file(file_path)
+
+        error = compute_percent_error(
+            aspect,
+            analytical,
+        )
+
+        ax.plot(
+            x,
+            error,
+            marker="o",
+            markersize=6,
+            linewidth=3,
+            color=color,
+            label=f"t={time_label}",
+        )
+
+    ax.set_xlim(X_RANGE)
+
+    ax.set_ylim(Y_RANGE_ERROR)
+
+    ax.set_xlabel("X [-]", fontsize=22)
+
+    ax.set_ylabel("Topography Error [%]", fontsize=22)
+
+    ax.set_title(
+        f"Surface Topography Error Benchmark\n{RUN_FOLDER}",
+        fontsize=26,
+    )
+
+    ax.grid(True, alpha=0.3)
+
+    ax.legend(
+        loc="upper center",
+        framealpha=1.0,
+        fontsize=16,
+    )
+
+    error_png = (
+        result_dir
+        / f"surface_topo_error_benchmark_ASPECT_{RUN_FOLDER}.png"
+    )
+
+    fig.savefig(
+        error_png,
+        dpi=300,
+        bbox_inches="tight",
+    )
+
+    plt.close(fig)
+
+    # =========================================================================
+    # SUMMARY
+    # =========================================================================
+
+    print()
+    print("============================================================")
+    print("Benchmark plots generated successfully")
+    print("============================================================")
+    print()
+    print("Topography plot:")
+    print(f"  {topo_png}")
+    print()
+    print("Error plot:")
+    print(f"  {error_png}")
+    print()
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

## Description

This pull request adds a benchmark recreation and verification workflow for the standalone ASPECT `diffusion_of_hill` benchmark within the Landlab–ASPECT coupling framework. The reproduced topography is compared with the analytical solution used in the original ASPECT benchmark, providing a quantitative verification of the Landlab–ASPECT coupling implementation and its ability to reproduce the expected diffusion-driven surface evolution.



### Added files

* `1_sine_zero_flux_landlab.prm`
* `1_shine_zero_flux_landlab_import-template.py`
* `plotter_Landlab_ASPECT_benchmark_diffusion_hill.py`

### Motivation

The purpose of this benchmark is to reproduce the standalone ASPECT diffusion benchmark located in:

```
benchmarks/diffusion_of_hill
```

using the Landlab mesh deformation plugin and compare the resulting topography evolution against the analytical solution already provided by ASPECT.

This benchmark serves as a verification case for the Landlab-ASPECT coupling framework and provides a reproducible workflow for evaluating whether Landlab-driven surface diffusion reproduces the expected analytical diffusion behavior.

### Main changes

#### PRM file modifications

The original benchmark uses:

```
Mesh deformation boundary indicators = top: diffusion
```

with the built-in ASPECT diffusion mesh deformation model.

This benchmark replaces it with:

```
Mesh deformation boundary indicators = top: Landlab
```

and configures the Landlab plugin through:

```
subsection Landlab
  set MPI ranks for Landlab = 1
  set Script name = 1_shine_zero_flux_landlab_import-template
end
```

The initial sinusoidal hill topography previously defined in:

```
Geometry model
  subsection Initial topography model
```

is instead generated inside the Landlab script so that the topographic evolution is entirely controlled by Landlab.

Additionally, the benchmark enables output of both numerical and analytical topography through:

```
Postprocess:
  analytical topography
  topography
```

allowing direct comparison between the Landlab-ASPECT solution and the analytical solution.

#### Landlab implementation

The new import-template:

* Creates a `RasterModelGrid` matching the ASPECT surface discretization.
* Initializes the sinusoidal hill:

```python
z = A * np.sin(np.pi * x / L)
```

with:

```python
A = 0.075
L = 1.0
```

* Applies closed boundary conditions on all grid edges.
* Evolves the surface using Landlab's `LinearDiffuser`.
* Uses substepping (`n_substeps = 10`) during each ASPECT timestep to improve numerical stability.
* Returns the computed erosion/deposition field to ASPECT through the Landlab-ASPECT coupling interface.

#### Benchmark plotting utility

A new plotting script:

```
plotter_Landlab_ASPECT_benchmark_diffusion_hill.py
```

was added to:

* Compare Landlab-ASPECT topography with the analytical solution.
* Compute mean absolute difference (MAD).
* Compute percentage error.
* Plot spatial distributions of topographic differences and associated errors for the coupled framework (two subplots of right column of figure attached here).

### Verification

The benchmark was run locally and compared against the analytical solution supplied by the existing ASPECT benchmark.

Figures comparing:

* Original standalone ASPECT benchmark results
* Landlab-ASPECT benchmark results
* Analytical solution

is attached here.

<img width="4385" height="3354" alt="stadalone_ASPECT_comparision_with_Coupled_Landlab-ASPECT_topo_analytical" src="https://github.com/user-attachments/assets/30fa4939-bbc4-4503-8a18-9c4b462fd452" />




### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
